### PR TITLE
Allows client to disable TLS

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -65,7 +65,7 @@ func (client *Client) Connect() error {
 		client.Config.Address = preferedNodeAddress
 	}
 	var opts []grpc.DialOption
-	if !client.Config.UseTls {
+	if client.Config.DisableTLS {
 		opts = append(opts, grpc.WithInsecure())
 	} else {
 		opts = append(opts,

--- a/client/client.go
+++ b/client/client.go
@@ -64,13 +64,22 @@ func (client *Client) Connect() error {
 		}
 		client.Config.Address = preferedNodeAddress
 	}
-	config := &tls.Config{
-		InsecureSkipVerify: client.Config.SkipCertificateVerification,
+	var opts []grpc.DialOption
+	if !client.Config.UseTls {
+		opts = append(opts, grpc.WithInsecure())
+	} else {
+		opts = append(opts,
+			grpc.WithTransportCredentials(credentials.NewTLS(
+				&tls.Config{
+					InsecureSkipVerify: client.Config.SkipCertificateVerification,
+				})))
 	}
-	conn, err := grpc.Dial(client.Config.Address, grpc.WithTransportCredentials(credentials.NewTLS(config)), grpc.WithPerRPCCredentials(basicAuth{
+	opts = append(opts, grpc.WithPerRPCCredentials(basicAuth{
 		username: client.Config.Username,
 		password: client.Config.Password,
 	}))
+
+	conn, err := grpc.Dial(client.Config.Address, opts...)
 	if err != nil {
 		return fmt.Errorf("Failed to initialize connection to %+v. Reason: %v", client.Config, err)
 	}

--- a/client/configuration.go
+++ b/client/configuration.go
@@ -4,7 +4,7 @@ package client
 type Configuration struct {
 	Address                     string
 	GossipSeeds                 []string
-	UseTls                      bool
+	DisableTLS                  bool
 	NodePreference              NodePreference
 	Username                    string
 	Password                    string


### PR DESCRIPTION
👋 Hi there,

I was experimenting with the Golang client and wanted to try things locally with eventstore (20.6) running in insecure mode. When trying to append events to a stream I got back errors like

```
Could not construct append operation. Reason: rpc error: code = Unavailable desc = connection error: desc = "transport: authentication handshake failed: tls: first record does not look like a TLS handshake"
```

which is expected in that situation.

This PR solves that by making use of `UseTls` configuration to disable TLS entirely when set to `false`.

I then figured that renaming that configuration option to `DisableTLS` would make more sense. Empty `Configuration{}` struct would become "secure" by default. As Go boolean zero value is `false`, this forces users to set `DisableTLS` to `true`. So I've done that too.

Thoughts?