### PR TITLE
fix: use high revision numbers to prevent using library reserved values

### DIFF
--- a/streamrevision/streamrevision.go
+++ b/streamrevision/streamrevision.go
@@ -5,11 +5,11 @@ type StreamRevision uint64
 
 const (
 	// StreamRevisionNoStream ...
-	StreamRevisionNoStream StreamRevision = iota
-	// StreamRevisionAny ...
-	StreamRevisionAny
+	StreamRevisionNoStream = StreamRevision(0)
 	// StreamRevisionStreamExists ...
-	StreamRevisionStreamExists
+	StreamRevisionStreamExists = StreamRevision(StreamRevisionEnd - 1)
+	// StreamRevisionAny ...
+	StreamRevisionAny = StreamRevision(StreamRevisionEnd - 2)
 )
 
 func NewStreamRevision(value uint64) StreamRevision {


### PR DESCRIPTION
The reserved values conflict with streams where you might want to use revision 1 but it uses `StreamRevisionAny` or revision 2 but it uses `StreamRevisionStreamExists`.

fixes #21 