### PR TITLE
fix: stream revision no stream conflict

### DIFF
--- a/streamrevision/streamrevision.go
+++ b/streamrevision/streamrevision.go
@@ -4,12 +4,12 @@ package streamrevision
 type StreamRevision uint64
 
 const (
-	// StreamRevisionNoStream ...
-	StreamRevisionNoStream = StreamRevision(0)
 	// StreamRevisionStreamExists ...
 	StreamRevisionStreamExists = StreamRevision(StreamRevisionEnd - 1)
 	// StreamRevisionAny ...
 	StreamRevisionAny = StreamRevision(StreamRevisionEnd - 2)
+	// StreamRevisionNoStream ...
+	StreamRevisionNoStream = StreamRevision(StreamRevisionEnd - 3)
 )
 
 func NewStreamRevision(value uint64) StreamRevision {


### PR DESCRIPTION
Please validate my assumptions below, but it seems to work this way.

The revision must be the number before not at the point of entry for an event.

If a stream has 1 event the revision needs to be 0 to add an event, if there is 2 events the revision needs to be 1.

So currently if you want to add an event at revision 1 (for the second event) you have to set the revision to `0` which conflicts with `StreamRevisionNoStream`.