### PR TITLE
Use channels for subscriptions

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -76,7 +76,7 @@ func (client *Client) Connect() error {
 			grpc.WithTransportCredentials(credentials.NewTLS(
 				&tls.Config{
 					InsecureSkipVerify: client.Config.SkipCertificateVerification,
-					RootCAs: client.Config.RootCAs,
+					RootCAs:            client.Config.RootCAs,
 				})))
 	}
 	opts = append(opts, grpc.WithPerRPCCredentials(basicAuth{
@@ -86,9 +86,9 @@ func (client *Client) Connect() error {
 
 	if client.Config.KeepAliveInterval >= 0 {
 		opts = append(opts, grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:					client.Config.KeepAliveInterval,
-			Timeout:				client.Config.KeepAliveTimeout,
-			PermitWithoutStream:	true,
+			Time:                client.Config.KeepAliveInterval,
+			Timeout:             client.Config.KeepAliveTimeout,
+			PermitWithoutStream: true,
 		}))
 	}
 
@@ -224,7 +224,7 @@ func (client *Client) ReadAllEvents(context context.Context, direction direction
 }
 
 // SubscribeToStream ...
-func (client *Client) SubscribeToStream(context context.Context, streamID string, from uint64, resolveLinks bool, eventAppeared chan <- messages.RecordedEvent, checkpointReached chan<- position.Position, subscriptionDropped chan<- string) (*subscription.Subscription, error) {
+func (client *Client) SubscribeToStream(context context.Context, streamID string, from uint64, resolveLinks bool, eventAppeared chan<- messages.RecordedEvent, checkpointReached chan<- position.Position, subscriptionDropped chan<- string) (*subscription.Subscription, error) {
 	subscriptionRequest, err := protoutils.ToStreamSubscriptionRequest(streamID, from, resolveLinks, nil)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to construct subscription. Reason: %v", err)
@@ -252,7 +252,7 @@ func (client *Client) SubscribeToStream(context context.Context, streamID string
 }
 
 // SubscribeToAll ...
-func (client *Client) SubscribeToAll(context context.Context, from position.Position, resolveLinks bool, eventAppeared chan <- messages.RecordedEvent, checkpointReached chan<- position.Position, subscriptionDropped chan<- string) (*subscription.Subscription, error) {
+func (client *Client) SubscribeToAll(context context.Context, from position.Position, resolveLinks bool, eventAppeared chan<- messages.RecordedEvent, checkpointReached chan<- position.Position, subscriptionDropped chan<- string) (*subscription.Subscription, error) {
 	subscriptionRequest, err := protoutils.ToAllSubscriptionRequest(from, resolveLinks, nil)
 	readClient, err := client.streamsClient.Read(context, subscriptionRequest)
 	if err != nil {
@@ -273,7 +273,7 @@ func (client *Client) SubscribeToAll(context context.Context, from position.Posi
 }
 
 // SubscribeToAllFiltered ...
-func (client *Client) SubscribeToAllFiltered(context context.Context, from position.Position, resolveLinks bool, filterOptions filtering.SubscriptionFilterOptions, eventAppeared chan <- messages.RecordedEvent, checkpointReached chan<- position.Position, subscriptionDropped chan<- string) (*subscription.Subscription, error) {
+func (client *Client) SubscribeToAllFiltered(context context.Context, from position.Position, resolveLinks bool, filterOptions filtering.SubscriptionFilterOptions, eventAppeared chan<- messages.RecordedEvent, checkpointReached chan<- position.Position, subscriptionDropped chan<- string) (*subscription.Subscription, error) {
 	subscriptionRequest, err := protoutils.ToAllSubscriptionRequest(from, resolveLinks, &filterOptions)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to construct subscription. Reason: %v", err)

--- a/client/client.go
+++ b/client/client.go
@@ -224,7 +224,7 @@ func (client *Client) ReadAllEvents(context context.Context, direction direction
 }
 
 // SubscribeToStream ...
-func (client *Client) SubscribeToStream(context context.Context, streamID string, from uint64, resolveLinks bool, eventAppeared func(messages.RecordedEvent), checkpointReached func(position.Position), subscriptionDropped func(reason string)) (*subscription.Subscription, error) {
+func (client *Client) SubscribeToStream(context context.Context, streamID string, from uint64, resolveLinks bool, eventAppeared chan <- messages.RecordedEvent, checkpointReached chan<- position.Position, subscriptionDropped chan<- string) (*subscription.Subscription, error) {
 	subscriptionRequest, err := protoutils.ToStreamSubscriptionRequest(streamID, from, resolveLinks, nil)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to construct subscription. Reason: %v", err)
@@ -252,7 +252,7 @@ func (client *Client) SubscribeToStream(context context.Context, streamID string
 }
 
 // SubscribeToAll ...
-func (client *Client) SubscribeToAll(context context.Context, from position.Position, resolveLinks bool, eventAppeared func(messages.RecordedEvent), checkpointReached func(position.Position), subscriptionDropped func(reason string)) (*subscription.Subscription, error) {
+func (client *Client) SubscribeToAll(context context.Context, from position.Position, resolveLinks bool, eventAppeared chan <- messages.RecordedEvent, checkpointReached chan<- position.Position, subscriptionDropped chan<- string) (*subscription.Subscription, error) {
 	subscriptionRequest, err := protoutils.ToAllSubscriptionRequest(from, resolveLinks, nil)
 	readClient, err := client.streamsClient.Read(context, subscriptionRequest)
 	if err != nil {
@@ -273,7 +273,7 @@ func (client *Client) SubscribeToAll(context context.Context, from position.Posi
 }
 
 // SubscribeToAllFiltered ...
-func (client *Client) SubscribeToAllFiltered(context context.Context, from position.Position, resolveLinks bool, filterOptions filtering.SubscriptionFilterOptions, eventAppeared func(messages.RecordedEvent), checkpointReached func(position.Position), subscriptionDropped func(reason string)) (*subscription.Subscription, error) {
+func (client *Client) SubscribeToAllFiltered(context context.Context, from position.Position, resolveLinks bool, filterOptions filtering.SubscriptionFilterOptions, eventAppeared chan <- messages.RecordedEvent, checkpointReached chan<- position.Position, subscriptionDropped chan<- string) (*subscription.Subscription, error) {
 	subscriptionRequest, err := protoutils.ToAllSubscriptionRequest(from, resolveLinks, &filterOptions)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to construct subscription. Reason: %v", err)

--- a/client/client.go
+++ b/client/client.go
@@ -224,7 +224,7 @@ func (client *Client) ReadAllEvents(context context.Context, direction direction
 }
 
 // SubscribeToStream ...
-func (client *Client) SubscribeToStream(context context.Context, streamID string, from uint64, resolveLinks bool, eventAppeared chan<- messages.RecordedEvent, checkpointReached chan<- position.Position, subscriptionDropped chan<- string) (*subscription.Subscription, error) {
+func (client *Client) SubscribeToStream(context context.Context, streamID string, from uint64, resolveLinks bool, eventAppeared chan<- interface{}, subscriptionDropped chan<- string) (*subscription.Subscription, error) {
 	subscriptionRequest, err := protoutils.ToStreamSubscriptionRequest(streamID, from, resolveLinks, nil)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to construct subscription. Reason: %v", err)
@@ -241,7 +241,7 @@ func (client *Client) SubscribeToStream(context context.Context, streamID string
 	case *api.ReadResp_Confirmation:
 		{
 			confirmation := readResult.GetConfirmation()
-			return subscription.NewSubscription(readClient, confirmation.SubscriptionId, eventAppeared, checkpointReached, subscriptionDropped), nil
+			return subscription.NewSubscription(readClient, confirmation.SubscriptionId, eventAppeared, subscriptionDropped), nil
 		}
 	case *api.ReadResp_StreamNotFound_:
 		{
@@ -252,7 +252,7 @@ func (client *Client) SubscribeToStream(context context.Context, streamID string
 }
 
 // SubscribeToAll ...
-func (client *Client) SubscribeToAll(context context.Context, from position.Position, resolveLinks bool, eventAppeared chan<- messages.RecordedEvent, checkpointReached chan<- position.Position, subscriptionDropped chan<- string) (*subscription.Subscription, error) {
+func (client *Client) SubscribeToAll(context context.Context, from position.Position, resolveLinks bool, eventAppeared chan<- interface{}, subscriptionDropped chan<- string) (*subscription.Subscription, error) {
 	subscriptionRequest, err := protoutils.ToAllSubscriptionRequest(from, resolveLinks, nil)
 	readClient, err := client.streamsClient.Read(context, subscriptionRequest)
 	if err != nil {
@@ -266,14 +266,14 @@ func (client *Client) SubscribeToAll(context context.Context, from position.Posi
 	case *api.ReadResp_Confirmation:
 		{
 			confirmation := readResult.GetConfirmation()
-			return subscription.NewSubscription(readClient, confirmation.SubscriptionId, eventAppeared, checkpointReached, subscriptionDropped), nil
+			return subscription.NewSubscription(readClient, confirmation.SubscriptionId, eventAppeared, subscriptionDropped), nil
 		}
 	}
 	return nil, fmt.Errorf("Failed to initiate subscription.")
 }
 
 // SubscribeToAllFiltered ...
-func (client *Client) SubscribeToAllFiltered(context context.Context, from position.Position, resolveLinks bool, filterOptions filtering.SubscriptionFilterOptions, eventAppeared chan<- messages.RecordedEvent, checkpointReached chan<- position.Position, subscriptionDropped chan<- string) (*subscription.Subscription, error) {
+func (client *Client) SubscribeToAllFiltered(context context.Context, from position.Position, resolveLinks bool, filterOptions filtering.SubscriptionFilterOptions, eventAppeared chan<- interface{}, subscriptionDropped chan<- string) (*subscription.Subscription, error) {
 	subscriptionRequest, err := protoutils.ToAllSubscriptionRequest(from, resolveLinks, &filterOptions)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to construct subscription. Reason: %v", err)
@@ -290,7 +290,7 @@ func (client *Client) SubscribeToAllFiltered(context context.Context, from posit
 	case *api.ReadResp_Confirmation:
 		{
 			confirmation := readResult.GetConfirmation()
-			return subscription.NewSubscription(readClient, confirmation.SubscriptionId, eventAppeared, checkpointReached, subscriptionDropped), nil
+			return subscription.NewSubscription(readClient, confirmation.SubscriptionId, eventAppeared, subscriptionDropped), nil
 		}
 	}
 	return nil, fmt.Errorf("Failed to initiate subscription.")

--- a/messages/checkpoint_event.go
+++ b/messages/checkpoint_event.go
@@ -1,0 +1,7 @@
+package messages
+
+// CheckpointEvent ...
+type CheckpointEvent struct {
+	Commit  uint64
+	Prepare uint64
+}

--- a/messages/checkpoint_event.go
+++ b/messages/checkpoint_event.go
@@ -2,6 +2,6 @@ package messages
 
 // CheckpointEvent ...
 type CheckpointEvent struct {
-	Commit  uint64
-	Prepare uint64
+	CommitPosition  uint64
+	PreparePosition uint64
 }

--- a/subscription/subscription.go
+++ b/subscription/subscription.go
@@ -77,8 +77,8 @@ func (subscription *Subscription) Start() {
 						checkpoint := result.GetCheckpoint()
 
 						subscription.eventAppeared <- messages.CheckpointEvent{
-							Commit:  checkpoint.CommitPosition,
-							Prepare: checkpoint.PreparePosition,
+							CommitPosition:  checkpoint.CommitPosition,
+							PreparePosition: checkpoint.PreparePosition,
 						}
 					}
 				case *api.ReadResp_Event:

--- a/subscription/subscription.go
+++ b/subscription/subscription.go
@@ -109,7 +109,13 @@ func (subscription *Subscription) Start() {
 					subscription.subscriptionDropped <- "User initiated"
 					subscriptionHasBeenDropped = true
 				}
-				errc <- subscription.readClient.CloseSend()
+
+				if err != nil {
+					errc <- err
+					subscription.readClient.CloseSend()
+				} else {
+					errc <- subscription.readClient.CloseSend()
+				}
 				return
 			}
 		}


### PR DESCRIPTION
This PR is meant to show how channels could be used for subscriptions by communicating data instead of sharing between goroutines.

Closes #11 