### PR TITLE
Fix ExcludeSystemEventsFilter Regex

### DIFF
--- a/esdb/types.go
+++ b/esdb/types.go
@@ -472,7 +472,7 @@ type SubscriptionFilter struct {
 func ExcludeSystemEventsFilter() *SubscriptionFilter {
 	return &SubscriptionFilter{
 		Type:  EventFilterType,
-		Regex: "/^[^\\$].*/",
+		Regex: "^[^\\$].*",
 	}
 }
 


### PR DESCRIPTION
The value for the Regex in the `ExcludeSystemEventsFilter` convenience function includes leading and trailing `/` characters. Using this function will cause all events not also including a leading and trailing `/` character to be filtered from the subscription, not just system events.

All test have been run and are passing locally following the test guidelines contained in the README.