### PR TITLE
Implement Logging abstraction.

### DIFF
--- a/esdb/endpoint.go
+++ b/esdb/endpoint.go
@@ -67,14 +67,18 @@ func ParseEndPoint(s string) (*EndPoint, error) {
 func NewGrpcClient(config Configuration) *grpcClient {
 	channel := make(chan msg)
 	closeFlag := new(int32)
+	logger := logger{
+		callback: config.Logger,
+	}
 
 	atomic.StoreInt32(closeFlag, 0)
 
-	go connectionStateMachine(config, closeFlag, channel)
+	go connectionStateMachine(config, closeFlag, channel, &logger)
 
 	return &grpcClient{
 		channel:   channel,
 		closeFlag: closeFlag,
 		once:      new(sync.Once),
+		logger:    &logger,
 	}
 }

--- a/esdb/logging.go
+++ b/esdb/logging.go
@@ -1,0 +1,60 @@
+package esdb
+
+import (
+	"fmt"
+	"log"
+	"strings"
+)
+
+type LogLevel = string
+
+const (
+	LogDebug LogLevel = "debug"
+	LogInfo  LogLevel = "info"
+	LogWarn  LogLevel = "warn"
+	LogError LogLevel = "error"
+)
+
+type LoggingFunc = func(level LogLevel, format string, args ...interface{})
+
+func ConsoleLogging() LoggingFunc {
+	return func(level LogLevel, format string, args ...interface{}) {
+		scoped := fmt.Sprintf("[%s]", level)
+		format = strings.Join([]string{scoped, format}, " ")
+		log.Printf(format, args...)
+	}
+}
+
+func NoopLogging() LoggingFunc {
+	return func(scope string, format string, args ...interface{}) {
+
+	}
+}
+
+type logger struct {
+	callback LoggingFunc
+}
+
+func (log *logger) error(format string, args ...interface{}) {
+	if log.callback != nil {
+		log.callback(LogError, format, args...)
+	}
+}
+
+func (log *logger) warn(format string, args ...interface{}) {
+	if log.callback != nil {
+		log.callback(LogWarn, format, args...)
+	}
+}
+
+func (log *logger) debug(format string, args ...interface{}) {
+	if log.callback != nil {
+		log.callback(LogDebug, format, args...)
+	}
+}
+
+func (log *logger) info(format string, args ...interface{}) {
+	if log.callback != nil {
+		log.callback(LogInfo, format, args...)
+	}
+}

--- a/esdb/persistent_subscription.go
+++ b/esdb/persistent_subscription.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sync/atomic"
 
-	"log"
 	"sync"
 
 	"github.com/EventStore/EventStore-Client-Go/v2/protos/persistent"
@@ -29,6 +28,7 @@ type PersistentSubscription struct {
 	once           *sync.Once
 	closed         *int32
 	cancel         context.CancelFunc
+	logger         *logger
 }
 
 func (connection *PersistentSubscription) Recv() *PersistentSubscriptionEvent {
@@ -44,7 +44,7 @@ func (connection *PersistentSubscription) Recv() *PersistentSubscriptionEvent {
 	if err != nil {
 		atomic.StoreInt32(connection.closed, 1)
 
-		log.Printf("[error] subscription has dropped. Reason: %v", err)
+		connection.logger.error("subscription has dropped. Reason: %v", err)
 
 		dropped := SubscriptionDropped{
 			Error: err,
@@ -146,6 +146,7 @@ func NewPersistentSubscription(
 	client persistent.PersistentSubscriptions_ReadClient,
 	subscriptionId string,
 	cancel context.CancelFunc,
+	logger *logger,
 ) *PersistentSubscription {
 	once := new(sync.Once)
 	closed := new(int32)
@@ -157,5 +158,6 @@ func NewPersistentSubscription(
 		once:           once,
 		closed:         closed,
 		cancel:         cancel,
+		logger:         logger,
 	}
 }

--- a/esdb/persistent_subscription_client.go
+++ b/esdb/persistent_subscription_client.go
@@ -50,7 +50,7 @@ func (client *persistentClient) ConnectToPersistentSubscription(
 			asyncConnection := NewPersistentSubscription(
 				readClient,
 				readResult.GetSubscriptionConfirmation().SubscriptionId,
-				cancel)
+				cancel, client.inner.logger)
 
 			return asyncConnection, nil
 		}

--- a/esdb/subscriptions.go
+++ b/esdb/subscriptions.go
@@ -3,7 +3,6 @@ package esdb
 import (
 	"context"
 	"fmt"
-	"log"
 	"sync"
 	"sync/atomic"
 
@@ -63,7 +62,7 @@ func (sub *Subscription) Recv() *SubscriptionEvent {
 
 	result, err := sub.inner.Recv()
 	if err != nil {
-		log.Printf("[error] subscription has dropped. Reason: %v", err)
+		sub.client.grpcClient.logger.error("subscription has dropped. Reason: %v", err)
 
 		dropped := SubscriptionDropped{
 			Error: err,


### PR DESCRIPTION
Fixes #117 

The designed solution is based upon the `LoggingFunc` callback.

```golang
type LoggingFunc = func(scope string, format string, args ...interface{})
```

By default, the library provides two implementations: `esdb.ConsoleLogging()` (enabled by default) and `esdb.NoopLogging()` (logs nothing).

Users can plug their own implementation by setting `esdb.Configuration` 's `Logger` property:

```golang
conf, err := esdb.ParseConnectionString("{connectionString}")
if err != nil {
    panic(err)
}

conf.Logger = myLoggingImpl()
db, err := esdb.NewClient(conf)
...
```