### PR TITLE
Respect the discoveryInterval connection configuration option.

### DIFF
--- a/esdb/impl.go
+++ b/esdb/impl.go
@@ -460,6 +460,10 @@ func discoverNode(conf Configuration, logger *logger) (*grpc.ClientConn, *Server
 	}
 
 	for attempt < conf.MaxDiscoverAttempts {
+		if attempt > 0 {
+			time.Sleep(time.Duration(conf.DiscoveryInterval) * time.Millisecond)
+		}
+
 		attempt += 1
 		logger.info("discovery attempt %v/%v", attempt, conf.MaxDiscoverAttempts)
 		for _, candidate := range candidates {

--- a/esdb/impl.go
+++ b/esdb/impl.go
@@ -460,10 +460,6 @@ func discoverNode(conf Configuration, logger *logger) (*grpc.ClientConn, *Server
 	}
 
 	for attempt < conf.MaxDiscoverAttempts {
-		if attempt > 0 {
-			time.Sleep(time.Duration(conf.DiscoveryInterval) * time.Millisecond)
-		}
-
 		attempt += 1
 		logger.info("discovery attempt %v/%v", attempt, conf.MaxDiscoverAttempts)
 		for _, candidate := range candidates {
@@ -531,6 +527,8 @@ func discoverNode(conf Configuration, logger *logger) (*grpc.ClientConn, *Server
 		if connection != nil {
 			break
 		}
+
+		time.Sleep(time.Duration(conf.DiscoveryInterval) * time.Millisecond)
 	}
 
 	if connection == nil {


### PR DESCRIPTION
The discoveryInterval connection configuration option exists on the
configuration object, but there is no logic that actually handles
discovery intervals.

This commit introduces the missing logic for handling discovery
intervals.