### PR TITLE
Set tag environment variable before starting cluster containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,12 @@ go test ./esdb
 docker-compose -f cluster-docker-compose.yml down
 ```
 
-By default the tests use `ghcr.io/eventstore/eventstore:ci`. To override this, set `EVENTSTORE_DOCKER_TAG_ENV` to the tag you wish to use:
+By default the tests use `ghcr.io/eventstore/eventstore:ci`. To override this, set the `EVENTSTORE_DOCKER_TAG_ENV` environment variable to the tag you wish to use:
 
 ```shell
+export EVENTSTORE_DOCKER_TAG_ENV="21.10.0-focal"
 docker-compose -f cluster-docker-compose.yml up -d 
-EVENTSTORE_DOCKER_TAG_ENV="21.10.0-focal" go test ./esdb
+go test ./esdb
 docker-compose -f cluster-docker-compose.yml down
 ```
 


### PR DESCRIPTION
If the `EVENTSTORE_DOCKER_TAG_ENV` environment variable is not yet set when starting the cluster docker compose file, it'll use the default `ci` image.