### PR TITLE
Add GetServerVersion() api method and update dataset log positions / tests

### DIFF
--- a/esdb/operations.go
+++ b/esdb/operations.go
@@ -1,0 +1,18 @@
+package esdb
+
+// ServerVersion Represents the version of an EventStoreDB node.
+type ServerVersion struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+// GetServerVersion Returns the version of the EventStoreDB node to which the client is currently connected.
+func (client *Client) GetServerVersion() (*ServerVersion, error) {
+	handle, err := client.grpcClient.getConnectionHandle()
+	if err != nil {
+		return nil, err
+	}
+
+	return handle.GetServerVersion();
+}

--- a/resources/test/dataset20M-1800-e0-e10.json
+++ b/resources/test/dataset20M-1800-e0-e10.json
@@ -54,8 +54,8 @@
         "nanos": 245917000
       },
       "position": {
-        "prepare": 18446744073709551615,
-        "commit": 18446744073709551615
+        "prepare": 11607400,
+        "commit": 11607400
       },
       "contentType": "application/json"
     }
@@ -115,8 +115,8 @@
         "nanos": 245936000
       },
       "position": {
-        "prepare": 18446744073709551615,
-        "commit": 18446744073709551615
+        "prepare": 11607557,
+        "commit": 11607557
       },
       "contentType": "application/json"
     }
@@ -176,8 +176,8 @@
         "nanos": 245940000
       },
       "position": {
-        "prepare": 18446744073709551615,
-        "commit": 18446744073709551615
+        "prepare": 11607714,
+        "commit": 11607714
       },
       "contentType": "application/json"
     }
@@ -237,8 +237,8 @@
         "nanos": 245943000
       },
       "position": {
-        "prepare": 18446744073709551615,
-        "commit": 18446744073709551615
+        "prepare": 11607871,
+        "commit": 11607871
       },
       "contentType": "application/json"
     }
@@ -298,8 +298,8 @@
         "nanos": 245955000
       },
       "position": {
-        "prepare": 18446744073709551615,
-        "commit": 18446744073709551615
+        "prepare": 11608028,
+        "commit": 11608028
       },
       "contentType": "application/json"
     }
@@ -359,8 +359,8 @@
         "nanos": 245958000
       },
       "position": {
-        "prepare": 18446744073709551615,
-        "commit": 18446744073709551615
+        "prepare": 11608185,
+        "commit": 11608185
       },
       "contentType": "application/json"
     }
@@ -420,8 +420,8 @@
         "nanos": 245962000
       },
       "position": {
-        "prepare": 18446744073709551615,
-        "commit": 18446744073709551615
+        "prepare": 11608342,
+        "commit": 11608342
       },
       "contentType": "application/json"
     }
@@ -481,8 +481,8 @@
         "nanos": 245964000
       },
       "position": {
-        "prepare": 18446744073709551615,
-        "commit": 18446744073709551615
+        "prepare": 11608499,
+        "commit": 11608499
       },
       "contentType": "application/json"
     }
@@ -542,8 +542,8 @@
         "nanos": 245968000
       },
       "position": {
-        "prepare": 18446744073709551615,
-        "commit": 18446744073709551615
+        "prepare": 11608656,
+        "commit": 11608656
       },
       "contentType": "application/json"
     }
@@ -603,8 +603,8 @@
         "nanos": 245970000
       },
       "position": {
-        "prepare": 18446744073709551615,
-        "commit": 18446744073709551615
+        "prepare": 11608813,
+        "commit": 11608813
       },
       "contentType": "application/json"
     }

--- a/resources/test/dataset20M-1800-e1999-e1990.json
+++ b/resources/test/dataset20M-1800-e1999-e1990.json
@@ -54,8 +54,8 @@
         "nanos": 521770000
       },
       "position": {
-        "prepare": 18446744073709551615,
-        "commit": 18446744073709551615
+        "prepare": 12237319,
+        "commit": 12237319
       },
       "contentType": "application/json"
     }
@@ -115,8 +115,8 @@
         "nanos": 521767000
       },
       "position": {
-        "prepare": 18446744073709551615,
-        "commit": 18446744073709551615
+        "prepare": 12237162,
+        "commit": 12237162
       },
       "contentType": "application/json"
     }
@@ -176,8 +176,8 @@
         "nanos": 521765000
       },
       "position": {
-        "prepare": 18446744073709551615,
-        "commit": 18446744073709551615
+        "prepare": 12237005,
+        "commit": 12237005
       },
       "contentType": "application/json"
     }
@@ -237,8 +237,8 @@
         "nanos": 521762000
       },
       "position": {
-        "prepare": 18446744073709551615,
-        "commit": 18446744073709551615
+        "prepare": 12236848,
+        "commit": 12236848
       },
       "contentType": "application/json"
     }
@@ -298,8 +298,8 @@
         "nanos": 521759000
       },
       "position": {
-        "prepare": 18446744073709551615,
-        "commit": 18446744073709551615
+        "prepare": 12236691,
+        "commit": 12236691
       },
       "contentType": "application/json"
     }
@@ -359,8 +359,8 @@
         "nanos": 521756000
       },
       "position": {
-        "prepare": 18446744073709551615,
-        "commit": 18446744073709551615
+        "prepare": 12236534,
+        "commit": 12236534
       },
       "contentType": "application/json"
     }
@@ -420,8 +420,8 @@
         "nanos": 521753000
       },
       "position": {
-        "prepare": 18446744073709551615,
-        "commit": 18446744073709551615
+        "prepare": 12236377,
+        "commit": 12236377
       },
       "contentType": "application/json"
     }
@@ -481,8 +481,8 @@
         "nanos": 521750000
       },
       "position": {
-        "prepare": 18446744073709551615,
-        "commit": 18446744073709551615
+        "prepare": 12236220,
+        "commit": 12236220
       },
       "contentType": "application/json"
     }
@@ -542,8 +542,8 @@
         "nanos": 521748000
       },
       "position": {
-        "prepare": 18446744073709551615,
-        "commit": 18446744073709551615
+        "prepare": 12236063,
+        "commit": 12236063
       },
       "contentType": "application/json"
     }
@@ -603,8 +603,8 @@
         "nanos": 521745000
       },
       "position": {
-        "prepare": 18446744073709551615,
-        "commit": 18446744073709551615
+        "prepare": 12235906,
+        "commit": 12235906
       },
       "contentType": "application/json"
     }


### PR DESCRIPTION
Added: GetServerVersion() api method
Updated: datasets with real prepare/commit log positions
Updated: read stream tests to cater for log position changes on the server

Context: https://github.com/EventStore/EventStore/pull/3459