### PR TITLE
Fix user credentials per call not working

### DIFF
--- a/esdb/auth_test.go
+++ b/esdb/auth_test.go
@@ -1,0 +1,102 @@
+package esdb_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/EventStore/EventStore-Client-Go/v3/esdb"
+)
+
+func AuthenticationTests(t *testing.T, tlsDBClient, insecureDBClient *esdb.Client) {
+	t.Run("AuthenticationTests", func(t *testing.T) {
+		t.Run("callInsecureWithoutCredentials", callInsecureWithoutCredentials(insecureDBClient))
+		t.Run("callInsecureWithInvalidCredentials", callInsecureWithInvalidCredentials(insecureDBClient))
+		t.Run("callWithTLSAndDefaultCredentials", callWithTLSAndDefaultCredentials(tlsDBClient))
+		t.Run("callWithTLSAndOverrideCredentials", callWithTLSAndOverrideCredentials(tlsDBClient))
+		t.Run("callWithTLSAndInvalidOverrideCredentials", callWithTLSAndInvalidOverrideCredentials(tlsDBClient))
+	})
+}
+
+func callInsecureWithoutCredentials(db *esdb.Client) TestCall {
+	return func(t *testing.T) {
+		context, cancel := context.WithTimeout(context.Background(), time.Duration(5)*time.Second)
+		defer cancel()
+
+		err := db.CreatePersistentSubscription(context, NAME_GENERATOR.Generate(), NAME_GENERATOR.Generate(), esdb.PersistentStreamSubscriptionOptions{})
+
+		if err != nil {
+			t.Fatalf("Unexpected failure %+v", err)
+		}
+	}
+}
+
+func callInsecureWithInvalidCredentials(db *esdb.Client) TestCall {
+	return func(t *testing.T) {
+		context, cancel := context.WithTimeout(context.Background(), time.Duration(5)*time.Second)
+		defer cancel()
+
+		opts := esdb.PersistentStreamSubscriptionOptions{
+			Authenticated: &esdb.Credentials{
+				Login:    "invalid",
+				Password: "invalid",
+			},
+		}
+		err := db.CreatePersistentSubscription(context, NAME_GENERATOR.Generate(), NAME_GENERATOR.Generate(), opts)
+
+		if err != nil {
+			t.Fatalf("Unexpected failure %+v", err)
+		}
+	}
+}
+
+func callWithTLSAndDefaultCredentials(db *esdb.Client) TestCall {
+	return func(t *testing.T) {
+		context, cancel := context.WithTimeout(context.Background(), time.Duration(5)*time.Second)
+		defer cancel()
+
+		err := db.CreatePersistentSubscription(context, NAME_GENERATOR.Generate(), NAME_GENERATOR.Generate(), esdb.PersistentStreamSubscriptionOptions{})
+
+		if err != nil {
+			t.Fatalf("Unexpected failure %+v", err)
+		}
+	}
+}
+
+func callWithTLSAndOverrideCredentials(db *esdb.Client) TestCall {
+	return func(t *testing.T) {
+		context, cancel := context.WithTimeout(context.Background(), time.Duration(5)*time.Second)
+		defer cancel()
+
+		opts := esdb.PersistentStreamSubscriptionOptions{
+			Authenticated: &esdb.Credentials{
+				Login:    "admin",
+				Password: "changeit",
+			},
+		}
+		err := db.CreatePersistentSubscription(context, NAME_GENERATOR.Generate(), NAME_GENERATOR.Generate(), opts)
+
+		if err != nil {
+			t.Fatalf("Unexpected failure %+v", err)
+		}
+	}
+}
+
+func callWithTLSAndInvalidOverrideCredentials(db *esdb.Client) TestCall {
+	return func(t *testing.T) {
+		context, cancel := context.WithTimeout(context.Background(), time.Duration(5)*time.Second)
+		defer cancel()
+
+		opts := esdb.PersistentStreamSubscriptionOptions{
+			Authenticated: &esdb.Credentials{
+				Login:    "invalid",
+				Password: "invalid",
+			},
+		}
+		err := db.CreatePersistentSubscription(context, NAME_GENERATOR.Generate(), NAME_GENERATOR.Generate(), opts)
+
+		if err == nil {
+			t.Fatalf("Unexpected succesfull completion!")
+		}
+	}
+}

--- a/esdb/client.go
+++ b/esdb/client.go
@@ -53,7 +53,7 @@ func (client *Client) AppendToStream(
 	streamsClient := api.NewStreamsClient(handle.Connection())
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(context, client.config, &opts, callOptions)
+	callOptions, ctx, cancel := configureGrpcCall(context, client.config, &opts, callOptions, client.grpcClient)
 	defer cancel()
 
 	appendOperation, err := streamsClient.Append(ctx, callOptions...)
@@ -240,7 +240,7 @@ func (client *Client) DeleteStream(
 	streamsClient := api.NewStreamsClient(handle.Connection())
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, &opts, callOptions)
+	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, &opts, callOptions, client.grpcClient)
 	defer cancel()
 	deleteRequest := toDeleteRequest(streamID, opts.ExpectedRevision)
 	deleteResponse, err := streamsClient.Delete(ctx, deleteRequest, callOptions...)
@@ -270,7 +270,7 @@ func (client *Client) TombstoneStream(
 	streamsClient := api.NewStreamsClient(handle.Connection())
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, &opts, callOptions)
+	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, &opts, callOptions, client.grpcClient)
 	defer cancel()
 	tombstoneRequest := toTombstoneRequest(streamID, opts.ExpectedRevision)
 	tombstoneResponse, err := streamsClient.Tombstone(ctx, tombstoneRequest, callOptions...)
@@ -333,7 +333,7 @@ func (client *Client) SubscribeToStream(
 	}
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, &opts, callOptions)
+	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, &opts, callOptions, client.grpcClient)
 
 	streamsClient := api.NewStreamsClient(handle.Connection())
 	subscriptionRequest, err := toStreamSubscriptionRequest(streamID, opts.From, opts.ResolveLinkTos, nil)
@@ -379,7 +379,7 @@ func (client *Client) SubscribeToAll(
 	streamsClient := api.NewStreamsClient(handle.Connection())
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, &opts, callOptions)
+	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, &opts, callOptions, client.grpcClient)
 
 	var filterOptions *SubscriptionFilterOptions = nil
 	if opts.Filter != nil {
@@ -751,7 +751,7 @@ func readInternal(
 ) (*ReadStream, error) {
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, options, callOptions)
+	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, options, callOptions, client.grpcClient)
 	result, err := streamsClient.Read(ctx, readRequest, callOptions...)
 	if err != nil {
 		defer cancel()

--- a/esdb/client_test.go
+++ b/esdb/client_test.go
@@ -25,7 +25,17 @@ func TestSingleNode(t *testing.T) {
 	t.Log("[debug] prepopulated database container started and ready to serve!")
 	//
 
-	// Those ReadAll tests need to be executed first because those are based on $all specific order.
+	// Insecure empty database container
+	t.Log("[debug] starting insecure database container...")
+	insecureContainer := GetInsecureDatabase(t)
+	defer insecureContainer.Close()
+	insecureContainerClient := CreateInsecureTestClient(insecureContainer, t)
+	defer insecureContainerClient.Close()
+	WaitForLeaderToBeElected(t, insecureContainerClient)
+	t.Log("[debug] insecure database container started and ready to serve!")
+	//
+
+	//// Those ReadAll tests need to be executed first because those are based on $all specific order.
 	ReadAllTests(t, populatedContainerClient)
 	ReadStreamTests(t, emptyContainerClient, populatedContainerClient)
 	SubscriptionTests(t, emptyContainerClient, populatedContainerClient)
@@ -35,6 +45,7 @@ func TestSingleNode(t *testing.T) {
 	PersistentSubReadTests(t, emptyContainerClient)
 	PersistentSubTests(t, emptyContainerClient, populatedContainerClient)
 	TLSTests(t, emptyContainer)
+	AuthenticationTests(t, emptyContainerClient, insecureContainerClient)
 }
 
 func TestClusterNode(t *testing.T) {

--- a/esdb/endpoint.go
+++ b/esdb/endpoint.go
@@ -78,12 +78,15 @@ func newGrpcClient(config Configuration) *grpcClient {
 
 	atomic.StoreInt32(closeFlag, 0)
 
-	go connectionStateMachine(config, closeFlag, channel, &logger)
+	auth := NewBasicPerCallAuth(config.Username, config.Password)
+
+	go connectionStateMachine(config, closeFlag, channel, &logger, auth)
 
 	return &grpcClient{
 		channel:   channel,
 		closeFlag: closeFlag,
 		once:      new(sync.Once),
 		logger:    &logger,
+		auth:      auth,
 	}
 }

--- a/esdb/errors.go
+++ b/esdb/errors.go
@@ -88,6 +88,9 @@ func (e *Error) Error() string {
 		msg = "[ErrorCodeInternalServer] unexpected error from the server, worthy of a GitHub issue"
 	case ErrorCodeNotLeader:
 		msg = "[ErrorCodeNotLeader] the request needing a leader node was executed on a follower node"
+	case ErrorUnavailable:
+		msg = "[ErrorUnavailable] the server is not ready to accept requests"
+
 	default:
 		msg = fmt.Sprintf("[ErrorCode %d] (sorry, this error code is not supported by the Error() method)", e.code)
 	}

--- a/esdb/impl.go
+++ b/esdb/impl.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
-	"google.golang.org/grpc/credentials/insecure"
 	"math/rand"
 	"strconv"
 	"strings"
@@ -20,6 +19,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -30,6 +30,11 @@ type grpcClient struct {
 	closeFlag *int32
 	once      *sync.Once
 	logger    *logger
+	auth      *basicPerCallAuth
+}
+
+func (client *grpcClient) setCallCredentials(c *Credentials) {
+	client.auth.setCallCredentials(c)
 }
 
 func (client *grpcClient) handleError(handle *connectionHandle, headers metadata.MD, trailers metadata.MD, err error) error {
@@ -190,7 +195,7 @@ func newConnectionHandle(id uuid.UUID, serverInfo *serverInfo, connection *grpc.
 	}
 }
 
-func connectionStateMachine(config Configuration, closeFlag *int32, channel chan msg, logger *logger) {
+func connectionStateMachine(config Configuration, closeFlag *int32, channel chan msg, logger *logger, auth *basicPerCallAuth) {
 	state := newConnectionState(config)
 
 	for {
@@ -213,7 +218,7 @@ func connectionStateMachine(config Configuration, closeFlag *int32, channel chan
 			{
 				// Means we need to create a grpc connection.
 				if state.correlation == uuid.Nil {
-					conn, serverInfo, err := discoverNode(state.config, logger)
+					conn, serverInfo, err := discoverNode(state.config, logger, auth)
 
 					if err != nil {
 						atomic.StoreInt32(closeFlag, 1)
@@ -258,7 +263,7 @@ func connectionStateMachine(config Configuration, closeFlag *int32, channel chan
 				}
 
 				logger.info("Connecting to leader node %s ...", evt.endpoint.String())
-				conn, err := createGrpcConnection(&state.config, evt.endpoint.String())
+				conn, err := createGrpcConnection(&state.config, evt.endpoint.String(), auth)
 
 				if err != nil {
 					logger.error("exception when connecting to suggested node %s", evt.endpoint.String())
@@ -292,7 +297,7 @@ func (msg reconnect) isMsg() {}
 
 const maxInboundMessageLength = 17 * 1_024 * 1_024 // 17 MiB
 
-func createGrpcConnection(conf *Configuration, address string) (*grpc.ClientConn, error) {
+func createGrpcConnection(conf *Configuration, address string, auth *basicPerCallAuth) (*grpc.ClientConn, error) {
 	var opts []grpc.DialOption
 	var transport credentials.TransportCredentials
 
@@ -308,13 +313,7 @@ func createGrpcConnection(conf *Configuration, address string) (*grpc.ClientConn
 
 	opts = append(opts, grpc.WithTransportCredentials(transport))
 	opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxInboundMessageLength)))
-
-	if conf.Username != "" {
-		opts = append(opts, grpc.WithPerRPCCredentials(basicAuth{
-			username: conf.Username,
-			password: conf.Password,
-		}))
-	}
+	opts = append(opts, grpc.WithPerRPCCredentials(auth))
 
 	if conf.KeepAliveInterval >= 0 {
 		opts = append(opts, grpc.WithKeepaliveParams(keepalive.ClientParameters{
@@ -421,22 +420,61 @@ func getSupportedMethods(ctx context.Context, conf *Configuration, conn *grpc.Cl
 	return &info, nil
 }
 
-type basicAuth struct {
-	username string
-	password string
+type perCallCredentials interface {
+	setCallCredentials(c *Credentials)
 }
 
-func (b basicAuth) GetRequestMetadata(tx context.Context, in ...string) (map[string]string, error) {
-	auth := b.username + ":" + b.password
-	enc := base64.StdEncoding.EncodeToString([]byte(auth))
-	return map[string]string{
-		"Authorization": "Basic " + enc,
-	}, nil
+type basicPerCallAuth struct {
+	defaultAuth string
+	callAuth    string
 }
 
-func (basicAuth) RequireTransportSecurity() bool {
+func NewBasicPerCallAuth(username, password string) *basicPerCallAuth {
+	auth := &basicPerCallAuth{
+		defaultAuth: "",
+		callAuth:    "",
+	}
+	auth.setDefaultCredentials(username, password)
+
+	return auth
+}
+
+func (b *basicPerCallAuth) GetRequestMetadata(tx context.Context, in ...string) (map[string]string, error) {
+	md := map[string]string{}
+
+	if b.callAuth != "" {
+		md["Authorization"] = b.callAuth
+	} else if b.defaultAuth != "" {
+		md["Authorization"] = b.defaultAuth
+	}
+
+	return md, nil
+}
+
+func (*basicPerCallAuth) RequireTransportSecurity() bool {
 	return false
 }
+
+func (b *basicPerCallAuth) setDefaultCredentials(username, password string) {
+	if username != "" {
+		b.defaultAuth = b.getAuth(username, password)
+	}
+}
+
+func (b *basicPerCallAuth) setCallCredentials(c *Credentials) {
+	if c != nil {
+		b.callAuth = b.getAuth(c.Login, c.Password)
+	} else {
+		b.callAuth = ""
+	}
+}
+
+func (*basicPerCallAuth) getAuth(username, password string) string {
+	auth := username + ":" + password
+	enc := base64.StdEncoding.EncodeToString([]byte(auth))
+	return "Basic " + enc
+}
+
 func allowedNodeState() []gossipApi.MemberInfo_VNodeState {
 	return []gossipApi.MemberInfo_VNodeState{
 		gossipApi.MemberInfo_Follower,
@@ -447,7 +485,7 @@ func allowedNodeState() []gossipApi.MemberInfo_VNodeState {
 	}
 }
 
-func discoverNode(conf Configuration, logger *logger) (*grpc.ClientConn, *serverInfo, error) {
+func discoverNode(conf Configuration, logger *logger, auth *basicPerCallAuth) (*grpc.ClientConn, *serverInfo, error) {
 	var connection *grpc.ClientConn = nil
 	var serverInfo *serverInfo = nil
 	var err error
@@ -479,7 +517,7 @@ func discoverNode(conf Configuration, logger *logger) (*grpc.ClientConn, *server
 		logger.info("discovery attempt %v/%v", attempt, conf.MaxDiscoverAttempts)
 		for _, candidate := range candidates {
 			logger.debug("trying candidate '%s'...", candidate)
-			connection, err = createGrpcConnection(&conf, candidate)
+			connection, err = createGrpcConnection(&conf, candidate, auth)
 			if err != nil {
 				logger.warn("error when creating a grpc connection for candidate %s: %v", candidate, err)
 				continue
@@ -511,7 +549,7 @@ func discoverNode(conf Configuration, logger *logger) (*grpc.ClientConn, *server
 				if candidate != selectedAddress {
 					candidate = selectedAddress
 					_ = connection.Close()
-					connection, err = createGrpcConnection(&conf, selectedAddress)
+					connection, err = createGrpcConnection(&conf, selectedAddress, auth)
 
 					if err != nil {
 						logger.warn("error when creating gRPC connection for the selected candidate '%s': %v", selectedAddress, err)

--- a/esdb/subscriptions_test.go
+++ b/esdb/subscriptions_test.go
@@ -20,6 +20,7 @@ func SubscriptionTests(t *testing.T, emptyDBClient *esdb.Client, populatedDBClie
 		t.Run("allSubscriptionWithFilterDeliversCorrectEvents", allSubscriptionWithFilterDeliversCorrectEvents(populatedDBClient))
 		t.Run("subscriptionAllFilter", subscriptionAllFilter(emptyDBClient))
 		t.Run("connectionClosing", connectionClosing(populatedDBClient))
+		t.Run("subscriptionAllWithCredentialsOverride", subscriptionAllWithCredentialsOverride(populatedDBClient))
 	})
 }
 
@@ -210,6 +211,24 @@ func connectionClosing(db *esdb.Client) TestCall {
 		droppedEvent.Add(1)
 		timedOut := waitWithTimeout(&droppedEvent, time.Duration(5)*time.Second)
 		require.False(t, timedOut, "Timed out waiting for dropped event")
+	}
+}
+
+func subscriptionAllWithCredentialsOverride(db *esdb.Client) TestCall {
+	return func(t *testing.T) {
+		opts := esdb.SubscribeToAllOptions{
+			Authenticated: &esdb.Credentials{
+				Login:    "admin",
+				Password: "changeit",
+			},
+			From:   esdb.Start{},
+			Filter: esdb.ExcludeSystemEventsFilter(),
+		}
+		_, err := db.SubscribeToAll(context.Background(), opts)
+
+		if err != nil {
+			t.Error(err)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixed: Configuring `WithPerRPCCredentials` more than once causes authentication to fail.