### PR TITLE
Fix using deprecated runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     name: Code generation & compile
     strategy:
       matrix:
-        os: [ ubuntu-18.04, windows-2019, macos-10.15 ]
+        os: [ ubuntu-latest, windows-2019, macos-10.15 ]
 
     runs-on: ${{ matrix.os }}
 
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         version: [ 20.10.5-buster-slim, 21.10.0-buster-slim, ci ]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v1
@@ -56,7 +56,7 @@ jobs:
   linting:
     needs: tests
     name: Linting
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Fixed: Stop using deprecated runner.

https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/