### PR TITLE
Fix using deprecated macos-10.15 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     name: Code generation & compile
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-2019, macos-10.15 ]
+        os: [ ubuntu-latest, windows-2019, macos-latest ]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Fixed: CI build stuck because specified runner is not available anymore.