### PR TITLE
Fix nil deref when reading last checkpointed event revision from a persistent subscription.

### DIFF
--- a/esdb/persistent_subscription_client.go
+++ b/esdb/persistent_subscription_client.go
@@ -397,7 +397,7 @@ func subscriptionInfoFromWire(wire *persistent.SubscriptionInfo) (*PersistentSub
 			}
 
 			stats.LastCheckpointedEventRevision = new(uint64)
-			*stats.LastKnownEventRevision = lastRev
+			*stats.LastCheckpointedEventRevision = lastRev
 		}
 	}
 


### PR DESCRIPTION
Fixed: Fix nil deref when reading last checkpointed event revision from a persistent subscription.

Fixes #150 