### PR TITLE
Fix race condition and overwriting when setting call credentials

### DIFF
--- a/esdb/client.go
+++ b/esdb/client.go
@@ -53,7 +53,7 @@ func (client *Client) AppendToStream(
 	streamsClient := api.NewStreamsClient(handle.Connection())
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(context, client.config, &opts, callOptions, client.grpcClient)
+	callOptions, ctx, cancel := configureGrpcCall(context, client.config, &opts, callOptions, client.grpcClient.perRPCCredentials)
 	defer cancel()
 
 	appendOperation, err := streamsClient.Append(ctx, callOptions...)
@@ -240,7 +240,7 @@ func (client *Client) DeleteStream(
 	streamsClient := api.NewStreamsClient(handle.Connection())
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, &opts, callOptions, client.grpcClient)
+	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, &opts, callOptions, client.grpcClient.perRPCCredentials)
 	defer cancel()
 	deleteRequest := toDeleteRequest(streamID, opts.ExpectedRevision)
 	deleteResponse, err := streamsClient.Delete(ctx, deleteRequest, callOptions...)
@@ -270,7 +270,7 @@ func (client *Client) TombstoneStream(
 	streamsClient := api.NewStreamsClient(handle.Connection())
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, &opts, callOptions, client.grpcClient)
+	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, &opts, callOptions, client.grpcClient.perRPCCredentials)
 	defer cancel()
 	tombstoneRequest := toTombstoneRequest(streamID, opts.ExpectedRevision)
 	tombstoneResponse, err := streamsClient.Tombstone(ctx, tombstoneRequest, callOptions...)
@@ -333,7 +333,7 @@ func (client *Client) SubscribeToStream(
 	}
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, &opts, callOptions, client.grpcClient)
+	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, &opts, callOptions, client.grpcClient.perRPCCredentials)
 
 	streamsClient := api.NewStreamsClient(handle.Connection())
 	subscriptionRequest, err := toStreamSubscriptionRequest(streamID, opts.From, opts.ResolveLinkTos, nil)
@@ -379,7 +379,7 @@ func (client *Client) SubscribeToAll(
 	streamsClient := api.NewStreamsClient(handle.Connection())
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, &opts, callOptions, client.grpcClient)
+	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, &opts, callOptions, client.grpcClient.perRPCCredentials)
 
 	var filterOptions *SubscriptionFilterOptions = nil
 	if opts.Filter != nil {
@@ -751,7 +751,7 @@ func readInternal(
 ) (*ReadStream, error) {
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, options, callOptions, client.grpcClient)
+	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, options, callOptions, client.grpcClient.perRPCCredentials)
 	result, err := streamsClient.Read(ctx, readRequest, callOptions...)
 	if err != nil {
 		defer cancel()

--- a/esdb/endpoint.go
+++ b/esdb/endpoint.go
@@ -84,7 +84,7 @@ func newGrpcClient(config Configuration) *grpcClient {
 
 	// Maybe construct RPC credentials from client config.
 	var perRPCCredentials credentials.PerRPCCredentials
-	if config.Username != "" && config.Password != "" {
+	if config.Username != "" && config.Password != "" && !config.DisableTLS {
 		perRPCCredentials = newBasicAuthPerRPCCredentials(config.Username, config.Password)
 	}
 

--- a/esdb/endpoint.go
+++ b/esdb/endpoint.go
@@ -78,15 +78,15 @@ func newGrpcClient(config Configuration) *grpcClient {
 
 	atomic.StoreInt32(closeFlag, 0)
 
-	auth := NewBasicPerCallAuth(config.Username, config.Password)
+	perRPCCredentials := NewBasicPerCallAuth(config.Username, config.Password)
 
-	go connectionStateMachine(config, closeFlag, channel, &logger, auth)
+	go connectionStateMachine(config, closeFlag, channel, &logger, perRPCCredentials)
 
 	return &grpcClient{
-		channel:   channel,
-		closeFlag: closeFlag,
-		once:      new(sync.Once),
-		logger:    &logger,
-		auth:      auth,
+		channel:           channel,
+		closeFlag:         closeFlag,
+		once:              new(sync.Once),
+		logger:            &logger,
+		perRPCCredentials: perRPCCredentials,
 	}
 }

--- a/esdb/impl.go
+++ b/esdb/impl.go
@@ -26,15 +26,11 @@ import (
 )
 
 type grpcClient struct {
-	channel   chan msg
-	closeFlag *int32
-	once      *sync.Once
-	logger    *logger
-	auth      *basicPerCallAuth
-}
-
-func (client *grpcClient) setCallCredentials(c *Credentials) {
-	client.auth.setCallCredentials(c)
+	channel           chan msg
+	closeFlag         *int32
+	once              *sync.Once
+	logger            *logger
+	perRPCCredentials credentials.PerRPCCredentials
 }
 
 func (client *grpcClient) handleError(handle *connectionHandle, headers metadata.MD, trailers metadata.MD, err error) error {
@@ -195,7 +191,7 @@ func newConnectionHandle(id uuid.UUID, serverInfo *serverInfo, connection *grpc.
 	}
 }
 
-func connectionStateMachine(config Configuration, closeFlag *int32, channel chan msg, logger *logger, auth *basicPerCallAuth) {
+func connectionStateMachine(config Configuration, closeFlag *int32, channel chan msg, logger *logger, perRPCCredentials credentials.PerRPCCredentials) {
 	state := newConnectionState(config)
 
 	for {
@@ -218,7 +214,7 @@ func connectionStateMachine(config Configuration, closeFlag *int32, channel chan
 			{
 				// Means we need to create a grpc connection.
 				if state.correlation == uuid.Nil {
-					conn, serverInfo, err := discoverNode(state.config, logger, auth)
+					conn, serverInfo, err := discoverNode(state.config, logger, perRPCCredentials)
 
 					if err != nil {
 						atomic.StoreInt32(closeFlag, 1)
@@ -263,7 +259,7 @@ func connectionStateMachine(config Configuration, closeFlag *int32, channel chan
 				}
 
 				logger.info("Connecting to leader node %s ...", evt.endpoint.String())
-				conn, err := createGrpcConnection(&state.config, evt.endpoint.String(), auth)
+				conn, err := createGrpcConnection(&state.config, evt.endpoint.String(), perRPCCredentials)
 
 				if err != nil {
 					logger.error("exception when connecting to suggested node %s", evt.endpoint.String())
@@ -297,7 +293,7 @@ func (msg reconnect) isMsg() {}
 
 const maxInboundMessageLength = 17 * 1_024 * 1_024 // 17 MiB
 
-func createGrpcConnection(conf *Configuration, address string, auth *basicPerCallAuth) (*grpc.ClientConn, error) {
+func createGrpcConnection(conf *Configuration, address string, perRPCCredentials credentials.PerRPCCredentials) (*grpc.ClientConn, error) {
 	var opts []grpc.DialOption
 	var transport credentials.TransportCredentials
 
@@ -313,8 +309,6 @@ func createGrpcConnection(conf *Configuration, address string, auth *basicPerCal
 
 	opts = append(opts, grpc.WithTransportCredentials(transport))
 	opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxInboundMessageLength)))
-	opts = append(opts, grpc.WithPerRPCCredentials(auth))
-
 	if conf.KeepAliveInterval >= 0 {
 		opts = append(opts, grpc.WithKeepaliveParams(keepalive.ClientParameters{
 			Time:                conf.KeepAliveInterval,
@@ -425,48 +419,29 @@ type perCallCredentials interface {
 }
 
 type basicPerCallAuth struct {
-	defaultAuth string
-	callAuth    string
+	headers map[string]string
 }
 
 func NewBasicPerCallAuth(username, password string) *basicPerCallAuth {
-	auth := &basicPerCallAuth{
-		defaultAuth: "",
-		callAuth:    "",
+	headers := map[string]string{}
+	if username != "" && password != "" {
+		headers["Authorization"] = "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password))
 	}
-	auth.setDefaultCredentials(username, password)
-
-	return auth
+	return &basicPerCallAuth{
+		headers: headers,
+	}
 }
 
 func (b *basicPerCallAuth) GetRequestMetadata(tx context.Context, in ...string) (map[string]string, error) {
-	md := map[string]string{}
-
-	if b.callAuth != "" {
-		md["Authorization"] = b.callAuth
-	} else if b.defaultAuth != "" {
-		md["Authorization"] = b.defaultAuth
-	}
-
-	return md, nil
+	return b.headers, nil
 }
 
 func (*basicPerCallAuth) RequireTransportSecurity() bool {
-	return false
-}
-
-func (b *basicPerCallAuth) setDefaultCredentials(username, password string) {
-	if username != "" {
-		b.defaultAuth = b.getAuth(username, password)
-	}
+	return false // Shouldn't this be true? Don't want to send password over insecure connection?
 }
 
 func (b *basicPerCallAuth) setCallCredentials(c *Credentials) {
-	if c != nil {
-		b.callAuth = b.getAuth(c.Login, c.Password)
-	} else {
-		b.callAuth = ""
-	}
+	panic("Don't call this!")
 }
 
 func (*basicPerCallAuth) getAuth(username, password string) string {
@@ -485,7 +460,7 @@ func allowedNodeState() []gossipApi.MemberInfo_VNodeState {
 	}
 }
 
-func discoverNode(conf Configuration, logger *logger, auth *basicPerCallAuth) (*grpc.ClientConn, *serverInfo, error) {
+func discoverNode(conf Configuration, logger *logger, perRPCCredentials credentials.PerRPCCredentials) (*grpc.ClientConn, *serverInfo, error) {
 	var connection *grpc.ClientConn = nil
 	var serverInfo *serverInfo = nil
 	var err error
@@ -517,7 +492,7 @@ func discoverNode(conf Configuration, logger *logger, auth *basicPerCallAuth) (*
 		logger.info("discovery attempt %v/%v", attempt, conf.MaxDiscoverAttempts)
 		for _, candidate := range candidates {
 			logger.debug("trying candidate '%s'...", candidate)
-			connection, err = createGrpcConnection(&conf, candidate, auth)
+			connection, err = createGrpcConnection(&conf, candidate, perRPCCredentials)
 			if err != nil {
 				logger.warn("error when creating a grpc connection for candidate %s: %v", candidate, err)
 				continue
@@ -549,7 +524,7 @@ func discoverNode(conf Configuration, logger *logger, auth *basicPerCallAuth) (*
 				if candidate != selectedAddress {
 					candidate = selectedAddress
 					_ = connection.Close()
-					connection, err = createGrpcConnection(&conf, selectedAddress, auth)
+					connection, err = createGrpcConnection(&conf, selectedAddress, perRPCCredentials)
 
 					if err != nil {
 						logger.warn("error when creating gRPC connection for the selected candidate '%s': %v", selectedAddress, err)

--- a/esdb/impl.go
+++ b/esdb/impl.go
@@ -429,7 +429,7 @@ func (b *basicAuthPerRPCCredentials) GetRequestMetadata(_ context.Context, _ ...
 }
 
 func (*basicAuthPerRPCCredentials) RequireTransportSecurity() bool {
-	return false // Shouldn't this be true? Don't want to send password over insecure connection?
+	return true
 }
 
 func allowedNodeState() []gossipApi.MemberInfo_VNodeState {

--- a/esdb/options.go
+++ b/esdb/options.go
@@ -41,7 +41,7 @@ func configureGrpcCall(ctx context.Context, conf *Configuration, options options
 	newCtx, cancel := context.WithDeadline(ctx, deadline)
 
 	// Maybe use RPC credentials from client method options instead of RPC credentials from client config.
-	if options.credentials() != nil {
+	if options.credentials() != nil && !conf.DisableTLS {
 		perRPCCredentials = newBasicAuthPerRPCCredentials(options.credentials().Login, options.credentials().Password)
 	}
 

--- a/esdb/options.go
+++ b/esdb/options.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -23,7 +24,7 @@ type options interface {
 	requiresLeader() bool
 }
 
-func configureGrpcCall(ctx context.Context, conf *Configuration, options options, grpcOptions []grpc.CallOption, auth perCallCredentials) ([]grpc.CallOption, context.Context, context.CancelFunc) {
+func configureGrpcCall(ctx context.Context, conf *Configuration, options options, grpcOptions []grpc.CallOption, perRPCCredentials credentials.PerRPCCredentials) ([]grpc.CallOption, context.Context, context.CancelFunc) {
 	var duration time.Duration
 
 	if options.deadline() != nil {
@@ -39,7 +40,12 @@ func configureGrpcCall(ctx context.Context, conf *Configuration, options options
 	deadline := time.Now().Add(duration)
 	newCtx, cancel := context.WithDeadline(ctx, deadline)
 
-	auth.setCallCredentials(options.credentials())
+	if options.credentials() != nil {
+		perRPCCredentials = NewBasicPerCallAuth(options.credentials().Login, options.credentials().Password)
+	}
+	if perRPCCredentials != nil {
+		grpcOptions = append(grpcOptions, grpc.PerRPCCredsCallOption{Creds: perRPCCredentials})
+	}
 
 	if options.requiresLeader() || conf.NodePreference == NodePreferenceLeader {
 		md := metadata.New(map[string]string{"requires-leader": "true"})

--- a/esdb/options.go
+++ b/esdb/options.go
@@ -40,9 +40,12 @@ func configureGrpcCall(ctx context.Context, conf *Configuration, options options
 	deadline := time.Now().Add(duration)
 	newCtx, cancel := context.WithDeadline(ctx, deadline)
 
+	// Maybe use RPC credentials from client method options instead of RPC credentials from client config.
 	if options.credentials() != nil {
-		perRPCCredentials = NewBasicPerCallAuth(options.credentials().Login, options.credentials().Password)
+		perRPCCredentials = newBasicAuthPerRPCCredentials(options.credentials().Login, options.credentials().Password)
 	}
+
+	// Maybe append RPC credentials to gRPC call options.
 	if perRPCCredentials != nil {
 		grpcOptions = append(grpcOptions, grpc.PerRPCCredsCallOption{Creds: perRPCCredentials})
 	}

--- a/esdb/persistent_subscription_client.go
+++ b/esdb/persistent_subscription_client.go
@@ -26,7 +26,7 @@ func (client *persistentClient) ConnectToPersistentSubscription(
 ) (*PersistentSubscription, error) {
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner)
+	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner.perRPCCredentials)
 	readClient, err := client.persistentSubscriptionClient.Read(ctx, callOptions...)
 	if err != nil {
 		defer cancel()
@@ -73,7 +73,7 @@ func (client *persistentClient) CreateStreamSubscription(
 	createSubscriptionConfig := createPersistentRequestProto(streamName, groupName, position, settings)
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner)
+	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner.perRPCCredentials)
 	defer cancel()
 	_, err := client.persistentSubscriptionClient.Create(ctx, createSubscriptionConfig, callOptions...)
 	if err != nil {
@@ -100,7 +100,7 @@ func (client *persistentClient) CreateAllSubscription(
 
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner)
+	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner.perRPCCredentials)
 	defer cancel()
 
 	_, err = client.persistentSubscriptionClient.Create(ctx, protoConfig, callOptions...)
@@ -124,7 +124,7 @@ func (client *persistentClient) UpdateStreamSubscription(
 	updateSubscriptionConfig := updatePersistentRequestStreamProto(streamName, groupName, position, settings)
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner)
+	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner.perRPCCredentials)
 	defer cancel()
 
 	_, err := client.persistentSubscriptionClient.Update(ctx, updateSubscriptionConfig, callOptions...)
@@ -148,7 +148,7 @@ func (client *persistentClient) UpdateAllSubscription(
 
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner)
+	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner.perRPCCredentials)
 	defer cancel()
 
 	_, err := client.persistentSubscriptionClient.Update(ctx, updateSubscriptionConfig, callOptions...)
@@ -170,7 +170,7 @@ func (client *persistentClient) DeleteStreamSubscription(
 	deleteSubscriptionOptions := deletePersistentRequestStreamProto(streamName, groupName)
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner)
+	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner.perRPCCredentials)
 	defer cancel()
 
 	_, err := client.persistentSubscriptionClient.Delete(ctx, deleteSubscriptionOptions, callOptions...)
@@ -191,7 +191,7 @@ func (client *persistentClient) DeleteAllSubscription(
 	deleteSubscriptionOptions := deletePersistentRequestAllOptionsProto(groupName)
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner)
+	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner.perRPCCredentials)
 	defer cancel()
 
 	_, err := client.persistentSubscriptionClient.Delete(ctx, deleteSubscriptionOptions, callOptions...)
@@ -239,7 +239,7 @@ func (client *persistentClient) listPersistentSubscriptions(
 
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner)
+	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner.perRPCCredentials)
 
 	defer cancel()
 
@@ -287,7 +287,7 @@ func (client *persistentClient) getPersistentSubscriptionInfo(
 
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner)
+	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner.perRPCCredentials)
 	defer cancel()
 
 	resp, err := client.persistentSubscriptionClient.GetInfo(ctx, getInfoReq, callOptions...)
@@ -336,7 +336,7 @@ func (client *persistentClient) replayParkedMessages(
 
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner)
+	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner.perRPCCredentials)
 	defer cancel()
 
 	_, err := client.persistentSubscriptionClient.ReplayParked(ctx, replayReq, callOptions...)
@@ -356,7 +356,7 @@ func (client *persistentClient) restartSubsystem(
 ) error {
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner)
+	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner.perRPCCredentials)
 	defer cancel()
 
 	_, err := client.persistentSubscriptionClient.RestartSubsystem(ctx, &shared.Empty{}, callOptions...)

--- a/esdb/tls_test.go
+++ b/esdb/tls_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -52,6 +53,14 @@ func testTLSDefaults(container *Container) TestCall {
 
 		_, err = c.ReadAll(context.Background(), opts, numberOfEvents)
 		require.Error(t, err)
+
+		// On MacOS, I didn't get "certificate signed by unknown authority", so doing this instead... -- John Bywater
+		if strings.Contains(err.Error(), "transport: authentication handshake failed: tls: failed to verify certificate: x509: “eventstoredb-node” certificate is not trusted") {
+			return
+		}
+		// Maybe check for "failed to verify certificate" instead of "certificate signed by unknown authority"?
+		//assert.Contains(t, err.Error(), "failed to verify certificate")
+
 		assert.Contains(t, err.Error(), "certificate signed by unknown authority")
 	}
 }
@@ -150,6 +159,14 @@ func testTLSWithoutCertificate(container *Container) TestCall {
 		}
 		_, err = c.ReadAll(context.Background(), opts, numberOfEvents)
 		require.Error(t, err)
+
+		// On MacOS, I didn't get "certificate signed by unknown authority", so doing this instead... -- John Bywater
+		if strings.Contains(err.Error(), "transport: authentication handshake failed: tls: failed to verify certificate: x509: “eventstoredb-node” certificate is not trusted") {
+			return
+		}
+		// Maybe check for "failed to verify certificate" instead of "certificate signed by unknown authority"?
+		//assert.Contains(t, err.Error(), "failed to verify certificate")
+
 		assert.Contains(t, err.Error(), "certificate signed by unknown authority")
 	}
 }

--- a/esdb/tls_test.go
+++ b/esdb/tls_test.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/ioutil"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -53,15 +52,7 @@ func testTLSDefaults(container *Container) TestCall {
 
 		_, err = c.ReadAll(context.Background(), opts, numberOfEvents)
 		require.Error(t, err)
-
-		// On MacOS, I didn't get "certificate signed by unknown authority", so doing this instead... -- John Bywater
-		if strings.Contains(err.Error(), "transport: authentication handshake failed: tls: failed to verify certificate: x509: “eventstoredb-node” certificate is not trusted") {
-			return
-		}
-		// Maybe check for "failed to verify certificate" instead of "certificate signed by unknown authority"?
-		//assert.Contains(t, err.Error(), "failed to verify certificate")
-
-		assert.Contains(t, err.Error(), "certificate signed by unknown authority")
+		assert.Contains(t, err.Error(), "failed to verify certificate")
 	}
 }
 
@@ -159,15 +150,7 @@ func testTLSWithoutCertificate(container *Container) TestCall {
 		}
 		_, err = c.ReadAll(context.Background(), opts, numberOfEvents)
 		require.Error(t, err)
-
-		// On MacOS, I didn't get "certificate signed by unknown authority", so doing this instead... -- John Bywater
-		if strings.Contains(err.Error(), "transport: authentication handshake failed: tls: failed to verify certificate: x509: “eventstoredb-node” certificate is not trusted") {
-			return
-		}
-		// Maybe check for "failed to verify certificate" instead of "certificate signed by unknown authority"?
-		//assert.Contains(t, err.Error(), "failed to verify certificate")
-
-		assert.Contains(t, err.Error(), "certificate signed by unknown authority")
+		assert.Contains(t, err.Error(), "failed to verify certificate")
 	}
 }
 


### PR DESCRIPTION
Fixed: Fix  race condition and overwriting when setting call credentials 

I adjusted the way "basic auth" call credentials are implemented, so that (1) the client configuration is not updated, (2) the client configuration is fully processed into a map of headers, (3) the connection is not given any call credentials, (4) call credentials are passed into each call as call options, (5) if credentials are provided in the options when a client method is called by user then a new credentials object is constructed and used as one of the gRPC call options, and (6) otherwise if the client been configured with credentials then those are used as one of the gRPC call options.

This means that the "global" credentials are not overwritten by credentials provided when a client method is called, and there isn't a race condition between concurrent client method calls on the overwriting of the "global" credentials.

I need this because I'm working on a project that has CI which fails on race conditions, and it failed on this race condition. Looking at it I also realised the (likely) issue of overwriting "default" client configured call credentials with credentials passed when a user calls a method (what the race condition is all about).

By the way, this is also how the Python client works, by passing in either the method credentials or otherwise the client credentials, for each call. For example [here](https://github.com/pyeventsourcing/esdbclient/blob/568d259951b6730c60306b62c53dec88628a15e4/esdbclient/client.py#L388) and [here](https://github.com/pyeventsourcing/esdbclient/blob/568d259951b6730c60306b62c53dec88628a15e4/esdbclient/client.py#L412) and [here](https://github.com/pyeventsourcing/esdbclient/blob/568d259951b6730c60306b62c53dec88628a15e4/esdbclient/client.py#L461) etc, 25 times.


