### PR TITLE
Fixed race condition and overwriting of call credentials.

### DIFF
--- a/esdb/client.go
+++ b/esdb/client.go
@@ -53,7 +53,7 @@ func (client *Client) AppendToStream(
 	streamsClient := api.NewStreamsClient(handle.Connection())
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(context, client.config, &opts, callOptions, client.grpcClient)
+	callOptions, ctx, cancel := configureGrpcCall(context, client.config, &opts, callOptions, client.grpcClient.perRPCCredentials)
 	defer cancel()
 
 	appendOperation, err := streamsClient.Append(ctx, callOptions...)
@@ -240,7 +240,7 @@ func (client *Client) DeleteStream(
 	streamsClient := api.NewStreamsClient(handle.Connection())
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, &opts, callOptions, client.grpcClient)
+	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, &opts, callOptions, client.grpcClient.perRPCCredentials)
 	defer cancel()
 	deleteRequest := toDeleteRequest(streamID, opts.ExpectedRevision)
 	deleteResponse, err := streamsClient.Delete(ctx, deleteRequest, callOptions...)
@@ -270,7 +270,7 @@ func (client *Client) TombstoneStream(
 	streamsClient := api.NewStreamsClient(handle.Connection())
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, &opts, callOptions, client.grpcClient)
+	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, &opts, callOptions, client.grpcClient.perRPCCredentials)
 	defer cancel()
 	tombstoneRequest := toTombstoneRequest(streamID, opts.ExpectedRevision)
 	tombstoneResponse, err := streamsClient.Tombstone(ctx, tombstoneRequest, callOptions...)
@@ -333,7 +333,7 @@ func (client *Client) SubscribeToStream(
 	}
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, &opts, callOptions, client.grpcClient)
+	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, &opts, callOptions, client.grpcClient.perRPCCredentials)
 
 	streamsClient := api.NewStreamsClient(handle.Connection())
 	subscriptionRequest, err := toStreamSubscriptionRequest(streamID, opts.From, opts.ResolveLinkTos, nil)
@@ -379,7 +379,7 @@ func (client *Client) SubscribeToAll(
 	streamsClient := api.NewStreamsClient(handle.Connection())
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, &opts, callOptions, client.grpcClient)
+	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, &opts, callOptions, client.grpcClient.perRPCCredentials)
 
 	var filterOptions *SubscriptionFilterOptions = nil
 	if opts.Filter != nil {
@@ -751,7 +751,7 @@ func readInternal(
 ) (*ReadStream, error) {
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, options, callOptions, client.grpcClient)
+	callOptions, ctx, cancel := configureGrpcCall(parent, client.config, options, callOptions, client.grpcClient.perRPCCredentials)
 	result, err := streamsClient.Read(ctx, readRequest, callOptions...)
 	if err != nil {
 		defer cancel()

--- a/esdb/persistent_subscription_client.go
+++ b/esdb/persistent_subscription_client.go
@@ -26,7 +26,7 @@ func (client *persistentClient) ConnectToPersistentSubscription(
 ) (*PersistentSubscription, error) {
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner)
+	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner.perRPCCredentials)
 	readClient, err := client.persistentSubscriptionClient.Read(ctx, callOptions...)
 	if err != nil {
 		defer cancel()
@@ -73,7 +73,7 @@ func (client *persistentClient) CreateStreamSubscription(
 	createSubscriptionConfig := createPersistentRequestProto(streamName, groupName, position, settings)
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner)
+	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner.perRPCCredentials)
 	defer cancel()
 	_, err := client.persistentSubscriptionClient.Create(ctx, createSubscriptionConfig, callOptions...)
 	if err != nil {
@@ -100,7 +100,7 @@ func (client *persistentClient) CreateAllSubscription(
 
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner)
+	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner.perRPCCredentials)
 	defer cancel()
 
 	_, err = client.persistentSubscriptionClient.Create(ctx, protoConfig, callOptions...)
@@ -124,7 +124,7 @@ func (client *persistentClient) UpdateStreamSubscription(
 	updateSubscriptionConfig := updatePersistentRequestStreamProto(streamName, groupName, position, settings)
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner)
+	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner.perRPCCredentials)
 	defer cancel()
 
 	_, err := client.persistentSubscriptionClient.Update(ctx, updateSubscriptionConfig, callOptions...)
@@ -148,7 +148,7 @@ func (client *persistentClient) UpdateAllSubscription(
 
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner)
+	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner.perRPCCredentials)
 	defer cancel()
 
 	_, err := client.persistentSubscriptionClient.Update(ctx, updateSubscriptionConfig, callOptions...)
@@ -170,7 +170,7 @@ func (client *persistentClient) DeleteStreamSubscription(
 	deleteSubscriptionOptions := deletePersistentRequestStreamProto(streamName, groupName)
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner)
+	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner.perRPCCredentials)
 	defer cancel()
 
 	_, err := client.persistentSubscriptionClient.Delete(ctx, deleteSubscriptionOptions, callOptions...)
@@ -191,7 +191,7 @@ func (client *persistentClient) DeleteAllSubscription(
 	deleteSubscriptionOptions := deletePersistentRequestAllOptionsProto(groupName)
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner)
+	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner.perRPCCredentials)
 	defer cancel()
 
 	_, err := client.persistentSubscriptionClient.Delete(ctx, deleteSubscriptionOptions, callOptions...)
@@ -239,7 +239,7 @@ func (client *persistentClient) listPersistentSubscriptions(
 
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner)
+	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner.perRPCCredentials)
 
 	defer cancel()
 
@@ -287,7 +287,7 @@ func (client *persistentClient) getPersistentSubscriptionInfo(
 
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner)
+	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner.perRPCCredentials)
 	defer cancel()
 
 	resp, err := client.persistentSubscriptionClient.GetInfo(ctx, getInfoReq, callOptions...)
@@ -336,7 +336,7 @@ func (client *persistentClient) replayParkedMessages(
 
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner)
+	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner.perRPCCredentials)
 	defer cancel()
 
 	_, err := client.persistentSubscriptionClient.ReplayParked(ctx, replayReq, callOptions...)
@@ -356,7 +356,7 @@ func (client *persistentClient) restartSubsystem(
 ) error {
 	var headers, trailers metadata.MD
 	callOptions := []grpc.CallOption{grpc.Header(&headers), grpc.Trailer(&trailers)}
-	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner)
+	callOptions, ctx, cancel := configureGrpcCall(parent, conf, options, callOptions, client.inner.perRPCCredentials)
 	defer cancel()
 
 	_, err := client.persistentSubscriptionClient.RestartSubsystem(ctx, &shared.Empty{}, callOptions...)

--- a/esdb/tls_test.go
+++ b/esdb/tls_test.go
@@ -52,7 +52,7 @@ func testTLSDefaults(container *Container) TestCall {
 
 		_, err = c.ReadAll(context.Background(), opts, numberOfEvents)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "certificate signed by unknown authority")
+		assert.Contains(t, err.Error(), "failed to verify certificate")
 	}
 }
 
@@ -150,7 +150,7 @@ func testTLSWithoutCertificate(container *Container) TestCall {
 		}
 		_, err = c.ReadAll(context.Background(), opts, numberOfEvents)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "certificate signed by unknown authority")
+		assert.Contains(t, err.Error(), "failed to verify certificate")
 	}
 }
 


### PR DESCRIPTION
Fixed: Fix race condition and overwriting when setting call credentials

I adjusted the way "basic auth" call credentials are implemented, so that (1) the client configuration is not updated, (2) the client configuration is fully processed into a map of headers, (3) the connection is not given any call credentials, (4) call credentials are passed into each call as call options, (5) if credentials are provided in the options when a client method is called by user then a new credentials object is constructed and used as one of the gRPC call options, and (6) otherwise if the client been configured with credentials then those are used as one of the gRPC call options.

This means that the "global" credentials are not overwritten by credentials provided when a client method is called, and there isn't a race condition between concurrent client method calls on the overwriting of the "global" credentials.

I need this because I'm working on a project that has CI which fails on race conditions, and it failed on this race condition. Looking at it I also realised the (likely) issue of overwriting "default" client configured call credentials with credentials passed when a user calls a method (what the race condition is all about).

By the way, this is also how the Python client works, by passing in either the method credentials or otherwise the client credentials, for each call. For example [here](https://github.com/pyeventsourcing/esdbclient/blob/568d259951b6730c60306b62c53dec88628a15e4/esdbclient/client.py#L388) and [here](https://github.com/pyeventsourcing/esdbclient/blob/568d259951b6730c60306b62c53dec88628a15e4/esdbclient/client.py#L412) and [here](https://github.com/pyeventsourcing/esdbclient/blob/568d259951b6730c60306b62c53dec88628a15e4/esdbclient/client.py#L461) etc, 25 times.