### PR TITLE
Add `IsErrorCode` to Error

### DIFF
--- a/esdb/errors.go
+++ b/esdb/errors.go
@@ -58,6 +58,11 @@ func (e *Error) Err() error {
 	return e.err
 }
 
+// IsErrorCode checks if the error code is the same as the given one.
+func (e *Error) IsErrorCode(code ErrorCode) bool {
+	return e.code == code
+}
+
 func (e *Error) Error() string {
 	msg := ""
 


### PR DESCRIPTION
Added: `IsErrorCode` to `Error` struct.

## Context

Useful when we want to check the error code, I found I use it primarily for the following two (but not limited to) in the write-side,

```go
if err, ok := esdb.FromError(err); !ok {
  if err.Code() == esdb.ErrorCodeWrongExpectedVersion {  }
  if err.Code() == esdb.ErrorCodeResourceNotFound { }
}
```