### PR TITLE
Add `OriginalStreamRevision` to ResolvedEvent

### DIFF
--- a/esdb/resolved_event.go
+++ b/esdb/resolved_event.go
@@ -18,3 +18,8 @@ func (resolved ResolvedEvent) OriginalEvent() *RecordedEvent {
 
 	return resolved.Event
 }
+
+// OriginalStreamRevision returns the stream revision of the original event.
+func (resolved ResolvedEvent) OriginalStreamRevision() StreamRevision {
+	return Revision(resolved.OriginalEvent().EventNumber)
+}

--- a/samples/appendingEvents.go
+++ b/samples/appendingEvents.go
@@ -152,7 +152,7 @@ func AppendWithConcurrencyCheck(db *esdb.Client) {
 	}
 
 	aopts := esdb.AppendToStreamOptions{
-		ExpectedRevision: esdb.Revision(lastEvent.OriginalEvent().EventNumber),
+		ExpectedRevision: lastEvent.OriginalStreamRevision(),
 	}
 
 	_, err = db.AppendToStream(context.Background(), "concurrency-stream", aopts, esdb.EventData{


### PR DESCRIPTION
Added: OriginalStreamRevision to ResolvedEvent

closes #148

## Context

When developing a Optimistic Concurrency Check, I made a mistake that having a function like this one would prevent to some extent:

```go
func getExpectedRevision(opts *Options, lastResolvedEvent *esdb.ResolvedEvent) ExpectedRevision {
	if opts != nil && opts.ExpectedRevision != nil {
		return opts.ExpectedRevision
	} else if lastResolvedEvent == nil {
		return NoStream{}
	} else {
                // I did this
                return Revision(lastResolvedEvent.Event.EventNumber)
	}
}
```

I changed the `samples` to reflect the intent.