### PR TITLE
Move to google uuid implementation.

### DIFF
--- a/esdb/append_test.go
+++ b/esdb/append_test.go
@@ -3,12 +3,12 @@ package esdb_test
 import (
 	"context"
 	"fmt"
+	"github.com/google/uuid"
 	"io"
 	"testing"
 	"time"
 
 	"github.com/EventStore/EventStore-Client-Go/v3/esdb"
-	uuid "github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,7 +16,7 @@ func createTestEvent() esdb.EventData {
 	event := esdb.EventData{
 		EventType:   "TestEvent",
 		ContentType: esdb.ContentTypeBinary,
-		EventID:     uuid.Must(uuid.NewV4()),
+		EventID:     uuid.New(),
 		Data:        []byte{0xb, 0xe, 0xe, 0xf},
 		Metadata:    []byte{0xd, 0xe, 0xa, 0xd},
 	}
@@ -57,9 +57,9 @@ func AppendTests(t *testing.T, emptyDB *Container, emptyDBClient *esdb.Client) {
 func appendToStreamSingleEventNoStream(db *esdb.Client) TestCall {
 	return func(t *testing.T) {
 		testEvent := createTestEvent()
-		testEvent.EventID = uuid.FromStringOrNil("38fffbc2-339e-11ea-8c7b-784f43837872")
+		testEvent.EventID = uuid.MustParse("38fffbc2-339e-11ea-8c7b-784f43837872")
 
-		streamID := uuid.Must(uuid.NewV4())
+		streamID := uuid.New()
 		context, cancel := context.WithTimeout(context.Background(), time.Duration(5)*time.Second)
 		defer cancel()
 
@@ -98,7 +98,7 @@ func appendToStreamSingleEventNoStream(db *esdb.Client) TestCall {
 
 func appendWithInvalidStreamRevision(db *esdb.Client) TestCall {
 	return func(t *testing.T) {
-		streamID, _ := uuid.NewV4()
+		streamID := uuid.New()
 		context, cancel := context.WithTimeout(context.Background(), time.Duration(5)*time.Second)
 		defer cancel()
 
@@ -134,7 +134,7 @@ func appendToSystemStreamWithIncorrectCredentials(container *Container) TestCall
 
 		defer db.Close()
 
-		streamID, _ := uuid.NewV4()
+		streamID := uuid.New()
 		context, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 		defer cancel()
 
@@ -151,7 +151,7 @@ func appendToSystemStreamWithIncorrectCredentials(container *Container) TestCall
 
 func metadataOperation(db *esdb.Client) TestCall {
 	return func(t *testing.T) {
-		streamID := uuid.Must(uuid.NewV4())
+		streamID := uuid.New()
 		context, cancel := context.WithTimeout(context.Background(), time.Duration(5)*time.Second)
 		defer cancel()
 

--- a/esdb/client_test.go
+++ b/esdb/client_test.go
@@ -103,4 +103,6 @@ func TestExpectations(t *testing.T) {
 
 func TestMisc(t *testing.T) {
 	ConnectionStringTests(t)
+	TestPositionParsing(t)
+	UUIDParsingTests(t)
 }

--- a/esdb/connection_test.go
+++ b/esdb/connection_test.go
@@ -2,11 +2,11 @@ package esdb_test
 
 import (
 	"context"
+	"github.com/google/uuid"
 	"testing"
 	"time"
 
 	"github.com/EventStore/EventStore-Client-Go/v3/esdb"
-	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,9 +21,9 @@ func closeConnection(container *Container) TestCall {
 		db := GetClient(t, container)
 
 		testEvent := createTestEvent()
-		testEvent.EventID = uuid.FromStringOrNil("38fffbc2-339e-11ea-8c7b-784f43837872")
+		testEvent.EventID = uuid.MustParse("38fffbc2-339e-11ea-8c7b-784f43837872")
 
-		streamID := uuid.Must(uuid.NewV4())
+		streamID := uuid.New()
 		context, cancel := context.WithTimeout(context.Background(), time.Duration(5)*time.Second)
 		defer cancel()
 		opts := esdb.AppendToStreamOptions{

--- a/esdb/event_data.go
+++ b/esdb/event_data.go
@@ -1,8 +1,6 @@
 package esdb
 
-import (
-	uuid "github.com/gofrs/uuid"
-)
+import "github.com/google/uuid"
 
 // ContentType event's content type.
 type ContentType int

--- a/esdb/impl.go
+++ b/esdb/impl.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
+	"github.com/google/uuid"
 	"math/rand"
 	"strconv"
 	"strings"
@@ -15,7 +16,6 @@ import (
 	gossipApi "github.com/EventStore/EventStore-Client-Go/v3/protos/gossip"
 	server_features "github.com/EventStore/EventStore-Client-Go/v3/protos/serverfeatures"
 	"github.com/EventStore/EventStore-Client-Go/v3/protos/shared"
-	"github.com/gofrs/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -225,7 +225,7 @@ func connectionStateMachine(config Configuration, closeFlag *int32, channel chan
 						return
 					}
 
-					state.correlation = uuid.Must(uuid.NewV4())
+					state.correlation = uuid.New()
 					state.connection = conn
 					state.serverInfo = serverInfo
 
@@ -274,7 +274,7 @@ func connectionStateMachine(config Configuration, closeFlag *int32, channel chan
 					continue
 				}
 
-				state.correlation = uuid.Must(uuid.NewV4())
+				state.correlation = uuid.New()
 				state.connection = conn
 				state.serverInfo = serverInfo
 

--- a/esdb/persistent_subscription.go
+++ b/esdb/persistent_subscription.go
@@ -3,13 +3,13 @@ package esdb
 import (
 	"context"
 	"fmt"
+	"github.com/google/uuid"
 	"sync/atomic"
 
 	"sync"
 
 	"github.com/EventStore/EventStore-Client-Go/v3/protos/persistent"
 	"github.com/EventStore/EventStore-Client-Go/v3/protos/shared"
-	"github.com/gofrs/uuid"
 )
 
 // NackAction persistent subscription acknowledgement error type.

--- a/esdb/persistent_subscription_client.go
+++ b/esdb/persistent_subscription_client.go
@@ -420,7 +420,7 @@ func subscriptionInfoFromWire(wire *persistent.SubscriptionInfo) (*PersistentSub
 		}
 	}
 
-	startFrom, err := parseStreamPosition(wire.StartFrom)
+	startFrom, err := ParseStreamPosition(wire.StartFrom)
 
 	if err != nil {
 		return nil, &Error{

--- a/esdb/persistent_subscription_http_client.go
+++ b/esdb/persistent_subscription_http_client.go
@@ -287,7 +287,7 @@ func parseEventRevision(input string) (uint64, error) {
 	}
 }
 
-func parseStreamPosition(input string) (interface{}, error) {
+func ParseStreamPosition(input string) (interface{}, error) {
 	if input == "0" || input == "C:0/P:0" {
 		return Start{}, nil
 	}
@@ -318,7 +318,7 @@ func fromHttpJsonInfo(src persistentSubscriptionInfoHttpJson) (*PersistentSubscr
 		settings.ConsumerStrategyName = ConsumerStrategy(src.Config.ConsumerStrategyName)
 
 		if src.EventStreamId == "$all" {
-			from, err := parseStreamPosition(src.Config.StartPosition)
+			from, err := ParseStreamPosition(src.Config.StartPosition)
 
 			if err != nil {
 				return nil, err

--- a/esdb/position_parsing_test.go
+++ b/esdb/position_parsing_test.go
@@ -1,44 +1,46 @@
-package esdb
+package esdb_test
 
 import (
-	"testing"
-
+	"github.com/EventStore/EventStore-Client-Go/v3/esdb"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestPositionParsing(t *testing.T) {
-	pos, err := parseStreamPosition("C:123/P:456")
-	assert.NoError(t, err)
-	assert.NotNil(t, pos)
+	t.Run("StreamPositionTests", func(t *testing.T) {
+		pos, err := esdb.ParseStreamPosition("C:123/P:456")
+		assert.NoError(t, err)
+		assert.NotNil(t, pos)
 
-	obj, err := parseStreamPosition("C:-1/P:-1")
-	assert.NoError(t, err)
+		obj, err := esdb.ParseStreamPosition("C:-1/P:-1")
+		assert.NoError(t, err)
 
-	_, ok := obj.(End)
-	assert.True(t, ok)
+		_, ok := obj.(esdb.End)
+		assert.True(t, ok)
 
-	obj, err = parseStreamPosition("C:0/P:0")
-	assert.NoError(t, err)
+		obj, err = esdb.ParseStreamPosition("C:0/P:0")
+		assert.NoError(t, err)
 
-	_, ok = obj.(Start)
-	assert.True(t, ok)
+		_, ok = obj.(esdb.Start)
+		assert.True(t, ok)
 
-	obj, err = parseStreamPosition("-1")
-	assert.NoError(t, err)
+		obj, err = esdb.ParseStreamPosition("-1")
+		assert.NoError(t, err)
 
-	_, ok = obj.(End)
-	assert.True(t, ok)
+		_, ok = obj.(esdb.End)
+		assert.True(t, ok)
 
-	obj, err = parseStreamPosition("0")
-	assert.NoError(t, err)
+		obj, err = esdb.ParseStreamPosition("0")
+		assert.NoError(t, err)
 
-	_, ok = obj.(Start)
-	assert.True(t, ok)
+		_, ok = obj.(esdb.Start)
+		assert.True(t, ok)
 
-	obj, err = parseStreamPosition("42")
-	assert.NoError(t, err)
+		obj, err = esdb.ParseStreamPosition("42")
+		assert.NoError(t, err)
 
-	value, ok := obj.(StreamRevision)
-	assert.True(t, ok)
-	assert.Equal(t, uint64(42), value.Value)
+		value, ok := obj.(esdb.StreamRevision)
+		assert.True(t, ok)
+		assert.Equal(t, uint64(42), value.Value)
+	})
 }

--- a/esdb/read_stream_test.go
+++ b/esdb/read_stream_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/google/uuid"
 	"io"
 	"io/ioutil"
 	"math"
@@ -11,7 +12,6 @@ import (
 	"time"
 
 	"github.com/EventStore/EventStore-Client-Go/v3/esdb"
-	uuid "github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/esdb/recorded_event.go
+++ b/esdb/recorded_event.go
@@ -1,9 +1,8 @@
 package esdb
 
 import (
+	"github.com/google/uuid"
 	"time"
-
-	uuid "github.com/gofrs/uuid"
 )
 
 // RecordedEvent represents a previously written event.

--- a/esdb/subscriptions_test.go
+++ b/esdb/subscriptions_test.go
@@ -3,6 +3,7 @@ package esdb_test
 import (
 	"context"
 	"encoding/json"
+	"github.com/google/uuid"
 	"io/ioutil"
 	"strings"
 	"sync"
@@ -10,7 +11,6 @@ import (
 	"time"
 
 	"github.com/EventStore/EventStore-Client-Go/v3/esdb"
-	uuid "github.com/gofrs/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -97,7 +97,7 @@ func streamSubscriptionDeliversAllEventsInStreamAndListensForNewEvents(db *esdb.
 
 		streamID := "dataset20M-0"
 		testEvent := createTestEvent()
-		testEvent.EventID = uuid.FromStringOrNil("84c8e36c-4e64-11ea-8b59-b7f658acfc9f")
+		testEvent.EventID = uuid.MustParse("84c8e36c-4e64-11ea-8b59-b7f658acfc9f")
 
 		var receivedEvents sync.WaitGroup
 		var appendedEvents sync.WaitGroup

--- a/esdb/uuid_parsing_test.go
+++ b/esdb/uuid_parsing_test.go
@@ -1,0 +1,20 @@
+package esdb_test
+
+import (
+	"github.com/EventStore/EventStore-Client-Go/v3/esdb"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func UUIDParsingTests(t *testing.T) {
+	t.Run("UUIDParsingTests", func(t *testing.T) {
+		expected := uuid.New()
+		most, least := esdb.UUIDAsInt64(expected)
+		actual, err := esdb.ParseUUIDFromInt64(most, least)
+
+		require.NoError(t, err)
+		assert.Equal(t, expected, actual)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/go-connections v0.5.0
-	github.com/gofrs/uuid v4.4.0+incompatible
+	github.com/google/uuid v1.6.0
 	github.com/goombaio/namegenerator v0.0.0-20181006234301-989e774b106e
 	github.com/stretchr/testify v1.8.4
 	github.com/testcontainers/testcontainers-go v0.28.0

--- a/go.sum
+++ b/go.sum
@@ -1327,8 +1327,6 @@ github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5x
 github.com/godbus/dbus/v5 v5.0.6/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
-github.com/gofrs/uuid v4.4.0+incompatible h1:3qXRTX8/NbyulANqlc0lchS1gqAVxRgsuW1YrTJupqA=
-github.com/gofrs/uuid v4.4.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/googleapis v1.2.0/go.mod h1:Njal3psf3qN6dwBtQfUmBZh2ybovJ0tlu3o/AC7HYjU=
 github.com/gogo/googleapis v1.4.0/go.mod h1:5YRNX2z1oM5gXdAkurHa942MDgEJyk02w4OecKY87+c=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=

--- a/samples/appendingEvents.go
+++ b/samples/appendingEvents.go
@@ -3,9 +3,8 @@ package samples
 import (
 	"context"
 	"encoding/json"
+	"github.com/google/uuid"
 	"log"
-
-	"github.com/gofrs/uuid"
 
 	"github.com/EventStore/EventStore-Client-Go/v3/esdb"
 )
@@ -53,7 +52,7 @@ func AppendWithSameId(db *esdb.Client) {
 		panic(err)
 	}
 
-	id := uuid.Must(uuid.NewV4())
+	id := uuid.New()
 	event := esdb.EventData{
 		ContentType: esdb.ContentTypeJson,
 		EventType:   "some-event",

--- a/samples/projectionManagement.go
+++ b/samples/projectionManagement.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/google/uuid"
 	"log"
 	"strings"
 
 	"github.com/EventStore/EventStore-Client-Go/v3/esdb"
-	"github.com/gofrs/uuid"
 )
 
 func CreateClient(connectionString string) {
@@ -163,7 +163,7 @@ fromAll()
 })
 .outputState()
 `
-	name := fmt.Sprintf("countEvent_Create_%s", uuid.Must(uuid.NewV4()))
+	name := fmt.Sprintf("countEvent_Create_%s", uuid.New())
 	err := client.Create(context.Background(), name, script, esdb.CreateProjectionOptions{})
 
 	if err != nil {

--- a/samples/quickstart.go
+++ b/samples/quickstart.go
@@ -5,9 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/google/uuid"
 	"io"
-
-	"github.com/gofrs/uuid"
 
 	"github.com/EventStore/EventStore-Client-Go/v3/esdb"
 )
@@ -29,7 +28,7 @@ func Run() {
 
 	// region createEvent
 	testEvent := TestEvent{
-		Id:            uuid.Must(uuid.NewV4()).String(),
+		Id:            uuid.NewString(),
 		ImportantData: "I wrote my first event!",
 	}
 


### PR DESCRIPTION
Changed: Move to google uuid implementation.

Fixes #45 

This PR introduces a breaking change. Consequentially, after that PR get merged, we are moving to `v4`.