### PR TITLE
Add CustomProperty and CustomProperties method to StreamMetadata

### DIFF
--- a/esdb/types.go
+++ b/esdb/types.go
@@ -268,13 +268,13 @@ func (m *StreamMetadata) StreamAcl() *Acl {
 }
 
 // CustomProperty The custom property value for the given key.
-func (m *StreamMetadata) CustomProperty(key string) (interface{}, bool) {
-	if m.customProperties == nil {
-		return nil, false
-	}
+func (m *StreamMetadata) CustomProperty(key string) interface{} {
+	return m.customProperties[key]
+}
 
-	value, ok := m.customProperties[key]
-	return value, ok
+// CustomProperties returns all custom properties.
+func (m *StreamMetadata) CustomProperties() map[string]interface{} {
+	return m.customProperties
 }
 
 // IsUserStreamAcl Checks if the ACL is set to users default.

--- a/esdb/types.go
+++ b/esdb/types.go
@@ -267,6 +267,16 @@ func (m *StreamMetadata) StreamAcl() *Acl {
 	return nil
 }
 
+// CustomProperty The custom property value for the given key.
+func (m *StreamMetadata) CustomProperty(key string) (interface{}, bool) {
+	if m.customProperties == nil {
+		return nil, false
+	}
+
+	value, ok := m.customProperties[key]
+	return value, ok
+}
+
 // IsUserStreamAcl Checks if the ACL is set to users default.
 func (m *StreamMetadata) IsUserStreamAcl() bool {
 	acl := m.Acl()

--- a/esdb/types_test.go
+++ b/esdb/types_test.go
@@ -74,3 +74,23 @@ func TestConsistentMetadataSerializationSystemStreamAcl(t *testing.T) {
 
 	assert.Equal(t, expected, *meta, "consistency serialization failure")
 }
+
+func TestCustomPropertyRetrievalFromStreamMetadata(t *testing.T) {
+	expected := esdb.StreamMetadata{}
+	expected.AddCustomProperty("foo", "bar")
+
+	foo, ok := expected.CustomProperty("foo")
+
+	assert.True(t, ok, "custom property not found")
+	assert.Equal(t, "bar", foo, "custom property value mismatch")
+}
+
+func TestUnknownCustomPropertyRetrievalFromStreamMetadata(t *testing.T) {
+	expected := esdb.StreamMetadata{}
+	expected.AddCustomProperty("foo", "bar")
+
+	foo, ok := expected.CustomProperty("foes")
+
+	assert.False(t, ok, "custom property found")
+	assert.Empty(t, foo, "custom property value mismatch")
+}

--- a/esdb/types_test.go
+++ b/esdb/types_test.go
@@ -79,9 +79,8 @@ func TestCustomPropertyRetrievalFromStreamMetadata(t *testing.T) {
 	expected := esdb.StreamMetadata{}
 	expected.AddCustomProperty("foo", "bar")
 
-	foo, ok := expected.CustomProperty("foo")
+	foo := expected.CustomProperty("foo")
 
-	assert.True(t, ok, "custom property not found")
 	assert.Equal(t, "bar", foo, "custom property value mismatch")
 }
 
@@ -89,8 +88,17 @@ func TestUnknownCustomPropertyRetrievalFromStreamMetadata(t *testing.T) {
 	expected := esdb.StreamMetadata{}
 	expected.AddCustomProperty("foo", "bar")
 
-	foo, ok := expected.CustomProperty("foes")
+	foo := expected.CustomProperty("foes")
 
-	assert.False(t, ok, "custom property found")
 	assert.Empty(t, foo, "custom property value mismatch")
+}
+
+func TestGetAllCustomPropertiesFromStreamMetadata(t *testing.T) {
+	expected := esdb.StreamMetadata{}
+	expected.AddCustomProperty("foo", 123)
+	expected.AddCustomProperty("foes", "baz")
+
+	props := expected.CustomProperties()
+
+	assert.Equal(t, map[string]interface{}{"foo": 123, "foes": "baz"}, props, "custom properties mismatch")
 }


### PR DESCRIPTION
Added: Add `CustomProperty` and `CustomProperties` method to `StreamMetadata`


Fixes #178 