### PR TITLE
Prevent from sending a message to an already closed channel.

### DIFF
--- a/esdb/client.go
+++ b/esdb/client.go
@@ -62,14 +62,14 @@ func (client *Client) AppendToStream(
 
 	appendOperation, err := streamsClient.Append(ctx, callOptions...)
 	if err != nil {
-		err = client.grpcClient.handleError(handle, headers, trailers, err)
+		err = client.grpcClient.handleError(handle, trailers, err)
 		return nil, fmt.Errorf("could not construct append operation. Reason: %w", err)
 	}
 
 	header := toAppendHeader(streamID, opts.ExpectedRevision)
 
 	if err := appendOperation.Send(header); err != nil {
-		err = client.grpcClient.handleError(handle, headers, trailers, err)
+		err = client.grpcClient.handleError(handle, trailers, err)
 		return nil, fmt.Errorf("could not send append request header. Reason: %w", err)
 	}
 
@@ -81,14 +81,14 @@ func (client *Client) AppendToStream(
 		}
 
 		if err = appendOperation.Send(appendRequest); err != nil {
-			err = client.grpcClient.handleError(handle, headers, trailers, err)
+			err = client.grpcClient.handleError(handle, trailers, err)
 			return nil, fmt.Errorf("could not send append request. Reason: %w", err)
 		}
 	}
 
 	response, err := appendOperation.CloseAndRecv()
 	if err != nil {
-		return nil, client.grpcClient.handleError(handle, headers, trailers, err)
+		return nil, client.grpcClient.handleError(handle, trailers, err)
 	}
 
 	result := response.GetResult()
@@ -249,7 +249,7 @@ func (client *Client) DeleteStream(
 	deleteRequest := toDeleteRequest(streamID, opts.ExpectedRevision)
 	deleteResponse, err := streamsClient.Delete(ctx, deleteRequest, callOptions...)
 	if err != nil {
-		err = client.grpcClient.handleError(handle, headers, trailers, err)
+		err = client.grpcClient.handleError(handle, trailers, err)
 		return nil, fmt.Errorf("failed to perform delete, details: %w", err)
 	}
 
@@ -280,7 +280,7 @@ func (client *Client) TombstoneStream(
 	tombstoneResponse, err := streamsClient.Tombstone(ctx, tombstoneRequest, callOptions...)
 
 	if err != nil {
-		err = client.grpcClient.handleError(handle, headers, trailers, err)
+		err = client.grpcClient.handleError(handle, trailers, err)
 		return nil, fmt.Errorf("failed to perform delete, details: %w", err)
 	}
 
@@ -347,13 +347,13 @@ func (client *Client) SubscribeToStream(
 	readClient, err := streamsClient.Read(ctx, subscriptionRequest, callOptions...)
 	if err != nil {
 		defer cancel()
-		err = client.grpcClient.handleError(handle, headers, trailers, err)
+		err = client.grpcClient.handleError(handle, trailers, err)
 		return nil, fmt.Errorf("failed to construct subscription. Reason: %w", err)
 	}
 	readResult, err := readClient.Recv()
 	if err != nil {
 		defer cancel()
-		err = client.grpcClient.handleError(handle, headers, trailers, err)
+		err = client.grpcClient.handleError(handle, trailers, err)
 		return nil, fmt.Errorf("failed to perform read. Reason: %w", err)
 	}
 	switch readResult.Content.(type) {
@@ -401,13 +401,13 @@ func (client *Client) SubscribeToAll(
 	readClient, err := streamsClient.Read(ctx, subscriptionRequest, callOptions...)
 	if err != nil {
 		defer cancel()
-		err = client.grpcClient.handleError(handle, headers, trailers, err)
+		err = client.grpcClient.handleError(handle, trailers, err)
 		return nil, fmt.Errorf("failed to construct subscription. Reason: %w", err)
 	}
 	readResult, err := readClient.Recv()
 	if err != nil {
 		defer cancel()
-		err = client.grpcClient.handleError(handle, headers, trailers, err)
+		err = client.grpcClient.handleError(handle, trailers, err)
 		return nil, fmt.Errorf("failed to perform read. Reason: %w", err)
 	}
 	switch readResult.Content.(type) {

--- a/esdb/persistent_subscription_client.go
+++ b/esdb/persistent_subscription_client.go
@@ -30,19 +30,19 @@ func (client *persistentClient) ConnectToPersistentSubscription(
 	readClient, err := client.persistentSubscriptionClient.Read(ctx, callOptions...)
 	if err != nil {
 		defer cancel()
-		return nil, client.inner.handleError(handle, headers, trailers, err)
+		return nil, client.inner.handleError(handle, trailers, err)
 	}
 
 	err = readClient.Send(toPersistentReadRequest(bufferSize, groupName, []byte(streamName)))
 	if err != nil {
 		defer cancel()
-		return nil, client.inner.handleError(handle, headers, trailers, err)
+		return nil, client.inner.handleError(handle, trailers, err)
 	}
 
 	readResult, err := readClient.Recv()
 	if err != nil {
 		defer cancel()
-		return nil, client.inner.handleError(handle, headers, trailers, err)
+		return nil, client.inner.handleError(handle, trailers, err)
 	}
 	switch readResult.Content.(type) {
 	case *persistent.ReadResp_SubscriptionConfirmation_:
@@ -77,7 +77,7 @@ func (client *persistentClient) CreateStreamSubscription(
 	defer cancel()
 	_, err := client.persistentSubscriptionClient.Create(ctx, createSubscriptionConfig, callOptions...)
 	if err != nil {
-		return client.inner.handleError(handle, headers, trailers, err)
+		return client.inner.handleError(handle, trailers, err)
 	}
 
 	return nil
@@ -105,7 +105,7 @@ func (client *persistentClient) CreateAllSubscription(
 
 	_, err = client.persistentSubscriptionClient.Create(ctx, protoConfig, callOptions...)
 	if err != nil {
-		return client.inner.handleError(handle, headers, trailers, err)
+		return client.inner.handleError(handle, trailers, err)
 	}
 
 	return nil
@@ -129,7 +129,7 @@ func (client *persistentClient) UpdateStreamSubscription(
 
 	_, err := client.persistentSubscriptionClient.Update(ctx, updateSubscriptionConfig, callOptions...)
 	if err != nil {
-		return client.inner.handleError(handle, headers, trailers, err)
+		return client.inner.handleError(handle, trailers, err)
 	}
 
 	return nil
@@ -153,7 +153,7 @@ func (client *persistentClient) UpdateAllSubscription(
 
 	_, err := client.persistentSubscriptionClient.Update(ctx, updateSubscriptionConfig, callOptions...)
 	if err != nil {
-		return client.inner.handleError(handle, headers, trailers, err)
+		return client.inner.handleError(handle, trailers, err)
 	}
 
 	return nil
@@ -175,7 +175,7 @@ func (client *persistentClient) DeleteStreamSubscription(
 
 	_, err := client.persistentSubscriptionClient.Delete(ctx, deleteSubscriptionOptions, callOptions...)
 	if err != nil {
-		return client.inner.handleError(handle, headers, trailers, err)
+		return client.inner.handleError(handle, trailers, err)
 	}
 
 	return nil
@@ -196,7 +196,7 @@ func (client *persistentClient) DeleteAllSubscription(
 
 	_, err := client.persistentSubscriptionClient.Delete(ctx, deleteSubscriptionOptions, callOptions...)
 	if err != nil {
-		return client.inner.handleError(handle, headers, trailers, err)
+		return client.inner.handleError(handle, trailers, err)
 	}
 
 	return nil
@@ -246,7 +246,7 @@ func (client *persistentClient) listPersistentSubscriptions(
 	resp, err := client.persistentSubscriptionClient.List(ctx, listReq, callOptions...)
 
 	if err != nil {
-		return nil, client.inner.handleError(handle, headers, trailers, err)
+		return nil, client.inner.handleError(handle, trailers, err)
 	}
 
 	var infos []PersistentSubscriptionInfo
@@ -292,7 +292,7 @@ func (client *persistentClient) getPersistentSubscriptionInfo(
 
 	resp, err := client.persistentSubscriptionClient.GetInfo(ctx, getInfoReq, callOptions...)
 	if err != nil {
-		return nil, client.inner.handleError(handle, headers, trailers, err)
+		return nil, client.inner.handleError(handle, trailers, err)
 	}
 
 	info, err := subscriptionInfoFromWire(resp.SubscriptionInfo)
@@ -342,7 +342,7 @@ func (client *persistentClient) replayParkedMessages(
 	_, err := client.persistentSubscriptionClient.ReplayParked(ctx, replayReq, callOptions...)
 
 	if err != nil {
-		return client.inner.handleError(handle, headers, trailers, err)
+		return client.inner.handleError(handle, trailers, err)
 	}
 
 	return nil
@@ -362,7 +362,7 @@ func (client *persistentClient) restartSubsystem(
 	_, err := client.persistentSubscriptionClient.RestartSubsystem(ctx, &shared.Empty{}, callOptions...)
 
 	if err != nil {
-		return client.inner.handleError(handle, headers, trailers, err)
+		return client.inner.handleError(handle, trailers, err)
 	}
 
 	return nil

--- a/esdb/projection_client.go
+++ b/esdb/projection_client.go
@@ -433,7 +433,7 @@ func (client *ProjectionClient) listInternal(
 
 		if err != nil {
 			if !errors.Is(err, io.EOF) {
-				err = client.inner.grpcClient.handleError(handle, headers, trailers, err)
+				err = client.inner.grpcClient.handleError(handle, trailers, err)
 				return nil, err
 			}
 

--- a/esdb/reads.go
+++ b/esdb/reads.go
@@ -48,7 +48,7 @@ func (stream *ReadStream) Recv() (*ResolvedEvent, error) {
 		atomic.StoreInt32(stream.closed, 1)
 
 		if !errors.Is(err, io.EOF) {
-			err = stream.params.client.handleError(stream.params.handle, *stream.params.headers, *stream.params.trailers, err)
+			err = stream.params.client.handleError(stream.params.handle, *stream.params.trailers, err)
 		}
 
 		return nil, err


### PR DESCRIPTION
Fixed: Prevent from sending a message to an already closed channel.

Fixes #187 

Not completely foolproof, but using an atomic boolean strikes a good balance between accuracy and performance.